### PR TITLE
Add scene setup and UI getter

### DIFF
--- a/js/engines/RenderEngine.js
+++ b/js/engines/RenderEngine.js
@@ -13,25 +13,31 @@ import { ButtonEngine } from '../managers/ButtonEngine.js';
  * 렌더링과 시각 효과를 담당하는 엔진입니다.
  */
 export class RenderEngine {
-    constructor(canvasId, eventManager, measureManager) {
-        console.log("\ud83c\udfa8 RenderEngine initialized.");
+    constructor(canvasId, eventManager, measureManager, logicManager, sceneManager) {
+        console.log("🎨 RenderEngine initialized.");
         this.renderer = new Renderer(canvasId);
-        this.cameraEngine = new CameraEngine(this.renderer, null, null); // 논리 매니저는 추후 주입
+        // 생성 시점에 logicManager와 sceneManager를 주입하여 CameraEngine을 초기화합니다.
+        this.cameraEngine = new CameraEngine(this.renderer, logicManager, sceneManager);
         this.layerEngine = new LayerEngine(this.renderer, this.cameraEngine);
 
+        // battleSimulationManager는 나중에 주입되므로 일단 null로 설정합니다.
         this.particleEngine = new ParticleEngine(measureManager, this.cameraEngine, null);
         this.animationManager = new AnimationManager(measureManager, null, this.particleEngine);
 
         this.buttonEngine = new ButtonEngine();
+        // heroManager 역시 나중에 주입됩니다.
         this.uiEngine = new UIEngine(this.renderer, measureManager, eventManager, null, this.buttonEngine, null);
         this.inputManager = new InputManager(this.renderer, this.cameraEngine, this.uiEngine, this.buttonEngine, eventManager);
     }
 
-    injectDependencies(battleSim, logicManager, sceneManager) {
-        this.cameraEngine.logicManager = logicManager;
-        this.cameraEngine.sceneManager = sceneManager;
+    injectDependencies(battleSim, heroManager) {
+        // 전투 관련 매니저를 주입하여 애니메이션과 파티클 시스템이 접근하도록 합니다.
         this.particleEngine.battleSimulationManager = battleSim;
         this.animationManager.battleSimulationManager = battleSim;
+
+        if (this.uiEngine) {
+            this.uiEngine.heroManager = heroManager;
+        }
     }
 
     draw() {


### PR DESCRIPTION
## Summary
- inject logic and scene managers into `RenderEngine`
- preload core managers earlier and register scenes/layers in `GameEngine`
- expose `getUIEngine` and `getBattleSimulationManager`

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68784f265c4c8327a5a101f5569583fc