### PR TITLE
Add UI managers and canvas injection

### DIFF
--- a/js/engines/RenderEngine.js
+++ b/js/engines/RenderEngine.js
@@ -13,9 +13,11 @@ import { ButtonEngine } from '../managers/ButtonEngine.js';
  * 렌더링과 시각 효과를 담당하는 엔진입니다.
  */
 export class RenderEngine {
-    constructor(canvasId, eventManager, measureManager, logicManager, sceneManager) {
+    // GameEngine에서 캔버스 요소를 직접 전달받도록 수정
+    constructor(canvasElement, eventManager, measureManager, logicManager, sceneManager) {
         console.log("🎨 RenderEngine initialized.");
-        this.renderer = new Renderer(canvasId);
+        // canvasId 대신 실제 DOM 요소를 받아 Renderer에 ID를 전달합니다.
+        this.renderer = new Renderer(canvasElement.id);
         // 생성 시점에 logicManager와 sceneManager를 주입하여 CameraEngine을 초기화합니다.
         this.cameraEngine = new CameraEngine(this.renderer, logicManager, sceneManager);
         this.layerEngine = new LayerEngine(this.renderer, this.cameraEngine);
@@ -28,6 +30,8 @@ export class RenderEngine {
         // heroManager 역시 나중에 주입됩니다.
         this.uiEngine = new UIEngine(this.renderer, measureManager, eventManager, null, this.buttonEngine, null);
         this.inputManager = new InputManager(this.renderer, this.cameraEngine, this.uiEngine, this.buttonEngine, eventManager);
+        // UIEngine 인스턴스를 ButtonEngine에 전달하여 버튼 클릭 시 UI 상호작용이 가능하도록 함
+        this.inputManager.buttonEngine.uiEngine = this.uiEngine;
     }
 
     injectDependencies(battleSim, heroManager) {
@@ -37,6 +41,11 @@ export class RenderEngine {
 
         if (this.uiEngine) {
             this.uiEngine.heroManager = heroManager;
+        }
+
+        // BattleSimulationManager가 LogicManager에 접근할 수 있도록 주입
+        if (battleSim) {
+            battleSim.logicManager = this.cameraEngine.logicManager;
         }
     }
 


### PR DESCRIPTION
## Summary
- inject GameEngine canvas element into RenderEngine
- wire up MercenaryPanelManager and BattleLogManager
- register BATTLE_START listener to switch scenes
- add CompatibilityManager and log layer

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687855bb456883278487556a72992199