### PR TITLE
Refactor manager creation

### DIFF
--- a/js/engines/BattleEngine.js
+++ b/js/engines/BattleEngine.js
@@ -6,10 +6,7 @@ import { WeightEngine } from '../managers/WeightEngine.js';
 import { StatManager } from '../managers/StatManager.js';
 import { DiceEngine } from '../managers/DiceEngine.js';
 import { DiceBotManager } from '../managers/DiceBotManager.js';
-import { HeroManager } from '../managers/HeroManager.js';
 import { BattleFormationManager } from '../managers/BattleFormationManager.js';
-import { MonsterSpawnManager } from '../managers/MonsterSpawnManager.js';
-import { StageDataManager } from '../managers/StageDataManager.js';
 import { DelayEngine } from '../managers/DelayEngine.js';
 import { TimingEngine } from '../managers/TimingEngine.js';
 import { CoordinateManager } from '../managers/CoordinateManager.js';
@@ -36,7 +33,6 @@ export class BattleEngine {
         const assetLoaderManager = assetEngine.getAssetLoaderManager();
         this.assetLoaderManager = assetLoaderManager;
         const animationManager = renderEngine.getAnimationManager();
-        this.stageDataManager = new StageDataManager();
 
         this.valorEngine = new ValorEngine();
         this.weightEngine = new WeightEngine();
@@ -95,14 +91,7 @@ export class BattleEngine {
             this.statusEffectManager
         );
 
-        this.heroManager = new HeroManager(idManager, this.diceEngine, assetLoaderManager, this.battleSimulationManager, assetEngine.getUnitSpriteEngine());
         this.battleFormationManager = new BattleFormationManager(this.battleSimulationManager);
-        this.monsterSpawnManager = new MonsterSpawnManager(
-            idManager,
-            assetLoaderManager,
-            this.battleSimulationManager,
-            this.stageDataManager
-        );
     }
 
     async setupBattle() {
@@ -110,7 +99,6 @@ export class BattleEngine {
         await this.assetLoaderManager.loadImage('sprite_zombie_default', 'assets/images/zombie.png');
 
         // 초기 전투 설정 시에는 영웅을 자동 생성하지 않습니다. 필요 시 UI에서 고용하도록 합니다.
-        await this.monsterSpawnManager.spawnMonstersForStage('stage1');
     }
 
     async startBattle() {
@@ -123,5 +111,4 @@ export class BattleEngine {
     }
 
     getBattleSimulationManager() { return this.battleSimulationManager; }
-    getStageDataManager() { return this.stageDataManager; }
 }

--- a/js/engines/RenderEngine.js
+++ b/js/engines/RenderEngine.js
@@ -34,8 +34,10 @@ export class RenderEngine {
         this.inputManager.buttonEngine.uiEngine = this.uiEngine;
     }
 
-    injectDependencies(battleSim, heroManager) {
-        // 전투 관련 매니저를 주입하여 애니메이션과 파티클 시스템이 접근하도록 합니다.
+    // 주입받는 인자를 객체 형태로 받아 유연성 확보
+    injectDependencies(dependencies) {
+        const { battleSim, heroManager } = dependencies;
+
         this.particleEngine.battleSimulationManager = battleSim;
         this.animationManager.battleSimulationManager = battleSim;
 
@@ -43,7 +45,6 @@ export class RenderEngine {
             this.uiEngine.heroManager = heroManager;
         }
 
-        // BattleSimulationManager가 LogicManager에 접근할 수 있도록 주입
         if (battleSim) {
             battleSim.logicManager = this.cameraEngine.logicManager;
         }

--- a/js/managers/UIEngine.js
+++ b/js/managers/UIEngine.js
@@ -1,7 +1,5 @@
 // js/managers/UIEngine.js
 
-// ... (기존 임포트 유지)
-// ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS } from '../constants.js';
 
 export class UIEngine {
@@ -22,7 +20,7 @@ export class UIEngine {
 
         this.recalculateUIDimensions();
 
-        // ✨ '전사 고용' 버튼 등록
+        // '전사 고용' 버튼을 초기 위치에 등록
         const hireButtonWidth = 150;
         const hireButtonHeight = 50;
         this.buttonEngine.registerButton(
@@ -53,10 +51,18 @@ export class UIEngine {
         this.mapPanelWidth = logicalCanvasWidth * this.measureManager.get('ui.mapPanelWidthRatio');
         this.mapPanelHeight = logicalCanvasHeight * this.measureManager.get('ui.mapPanelHeightRatio');
 
-        // ✨ '전투 시작' 버튼은 HTML에서 관리하므로 여기서는 UI 폰트 크기만 계산합니다.
         this.uiFontSize = Math.floor(logicalCanvasHeight * this.measureManager.get('ui.fontSizeRatio'));
 
-        // ButtonEngine에 등록된 다른 버튼이 있다면 이곳에서 위치 정보를 업데이트할 수 있습니다.
+        // 화면 크기가 변할 때 버튼 위치도 업데이트합니다.
+        const hireButtonWidth = 150;
+        const hireButtonHeight = 50;
+        this.buttonEngine.updateButtonRect(
+            BUTTON_IDS.HIRE_WARRIOR,
+            logicalCanvasWidth - hireButtonWidth - 20,
+            20,
+            hireButtonWidth,
+            hireButtonHeight
+        );
 
         console.log(`[UIEngine Debug] Canvas Logical Dimensions: ${logicalCanvasWidth}x${logicalCanvasHeight}`);
     }


### PR DESCRIPTION
## Summary
- update `UIEngine` to reposition hire button when screen size changes
- shift `HeroManager` and monster spawning responsibilities to `GameEngine`
- allow `RenderEngine` to accept dependency objects
- remove hero/monster managers from `BattleEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878578550f88327a4d609e0e1a9921d