### PR TITLE
Add asset preload and UI layout fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,14 @@
 <body>
     <div id="gameContainer">
         <canvas id="gameCanvas"></canvas>
-        <canvas id="combatLogCanvas"></canvas>
     </div>
+
+    <div id="bottomUiContainer">
+        <canvas id="combatLogCanvas"></canvas>
+        <button id="battleStartHtmlBtn" class="game-button">전투 시작</button>
+    </div>
+
     <button id="toggleHeroPanelBtn" style="position: absolute; top: 10px; right: 10px; z-index: 100;">영웅 패널</button>
-    <!-- ✨ 캔버스 버튼 외에 별도의 HTML 전투 시작 버튼 -->
-    <button id="battleStartHtmlBtn" class="game-button">전투 시작</button>
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/engines/BattleEngine.js
+++ b/js/engines/BattleEngine.js
@@ -106,10 +106,10 @@ export class BattleEngine {
     }
 
     async setupBattle() {
-        await this.assetLoaderManager.loadImage('sprite_warrior_default', 'assets/images/warrior.png');
-        await this.assetLoaderManager.loadImage('sprite_zombie_default', 'assets/images/zombie.png');
-
         // 초기 전투 설정 시에는 영웅을 자동 생성하지 않습니다. 필요 시 UI에서 고용하도록 합니다.
+        if (this.monsterSpawnManager) {
+            await this.monsterSpawnManager.spawnMonstersForStage('stage1');
+        }
     }
 
     async startBattle() {

--- a/js/managers/BattleGridManager.js
+++ b/js/managers/BattleGridManager.js
@@ -39,8 +39,8 @@ export class BattleGridManager {
         const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
         const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
-        console.log(`[BattleGridManager Debug] Drawing Grid Parameters (in draw()): \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\n            Scene Content (Logical): ${sceneContentDimensions.width}x${sceneContentDimensions.height}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}\n            Total Grid Render Size (Logical): ${totalGridWidth.toFixed(2)}x${totalGridHeight.toFixed(2)}`
-        );
+//         console.log(`[BattleGridManager Debug] Drawing Grid Parameters (in draw()): \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\n            Scene Content (Logical): ${sceneContentDimensions.width}x${sceneContentDimensions.height}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}\n            Total Grid Render Size (Logical): ${totalGridWidth.toFixed(2)}x${totalGridHeight.toFixed(2)}`
+//         );
 
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)';
         ctx.lineWidth = 1;
@@ -48,7 +48,7 @@ export class BattleGridManager {
         // 세로선 그리기
         for (let i = 0; i <= this.gridCols; i++) {
             const lineX = gridOffsetX + i * effectiveTileSize;
-            console.log(`[BattleGridManager Debug] Vertical Line ${i}: X=${lineX.toFixed(2)} from Y=${gridOffsetY.toFixed(2)} to Y=${(gridOffsetY + totalGridHeight).toFixed(2)}`);
+//             console.log(`[BattleGridManager Debug] Vertical Line ${i}: X=${lineX.toFixed(2)} from Y=${gridOffsetY.toFixed(2)} to Y=${(gridOffsetY + totalGridHeight).toFixed(2)}`);
             ctx.beginPath();
             ctx.moveTo(lineX, gridOffsetY);
             ctx.lineTo(lineX, gridOffsetY + totalGridHeight);
@@ -58,7 +58,7 @@ export class BattleGridManager {
         // 가로선 그리기
         for (let i = 0; i <= this.gridRows; i++) {
             const lineY = gridOffsetY + i * effectiveTileSize;
-            console.log(`[BattleGridManager Debug] Horizontal Line ${i}: Y=${lineY.toFixed(2)} from X=${gridOffsetX.toFixed(2)} to X=${(gridOffsetX + totalGridWidth).toFixed(2)}`);
+//             console.log(`[BattleGridManager Debug] Horizontal Line ${i}: Y=${lineY.toFixed(2)} from X=${gridOffsetX.toFixed(2)} to X=${(gridOffsetX + totalGridWidth).toFixed(2)}`);
             ctx.beginPath();
             ctx.moveTo(gridOffsetX, lineY);
             ctx.lineTo(gridOffsetX + totalGridWidth, lineY);
@@ -66,7 +66,7 @@ export class BattleGridManager {
         }
 
         // 그리드 영역 테두리 (확인용)
-        console.log(`[BattleGridManager Debug] Border Rect: X=${gridOffsetX.toFixed(2)}, Y=${gridOffsetY.toFixed(2)}, W=${totalGridWidth.toFixed(2)}, H=${totalGridHeight.toFixed(2)}`);
+//         console.log(`[BattleGridManager Debug] Border Rect: X=${gridOffsetX.toFixed(2)}, Y=${gridOffsetY.toFixed(2)}, W=${totalGridWidth.toFixed(2)}, H=${totalGridHeight.toFixed(2)}`);
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
         ctx.lineWidth = 2;
         ctx.strokeRect(gridOffsetX, gridOffsetY, totalGridWidth, totalGridHeight);

--- a/style.css
+++ b/style.css
@@ -1,64 +1,56 @@
 body {
     margin: 0;
-    overflow: hidden; /* 스크롤바 방지 */
+    overflow: hidden;
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     min-height: 100vh;
-    background-color: #333; /* 배경색 */
-    flex-direction: column; /* 자식 요소들을 세로로 정렬 */
+    background-color: #333;
 }
 
-/* 두 캔버스를 담는 컨테이너 */
 #gameContainer {
-    display: flex;
-    flex-direction: column; /* 캔버스들을 세로로 정렬 */
-    align-items: center; /* 컨테이너 내에서 캔버스들을 수평 중앙 정렬 */
-    /* 컨테이너가 뷰포트 최대 크기를 차지하도록 */
-    width: 100vw;
-    height: 100vh;
-    box-sizing: border-box;
-    padding: 0px;
-    justify-content: center; /* 세로 중앙 정렬 */
-}
-
-canvas {
-    border: 2px solid #fff; /* 캔버스 테두리 */
-    background-color: #000; /* 캔버스 배경 */
-    display: block; /* 캔버스 아래 추가 공간 방지 */
-    max-width: 100%; /* 부모 컨테이너 너비를 넘지 않도록 */
-    box-sizing: border-box; /* 테두리 포함 크기 계산 */
-}
-
-/* 용병 패널 캔버스 스타일은 이제 필요 없습니다. */
-
-/* ✨ 전투 로그 캔버스 전용 스타일 (JS가 크기 제어) */
-#combatLogCanvas {
-    margin-top: 0px; /* 메인 게임 캔버스 위쪽 간격을 제거 */
-    border: 2px solid #f00; /* 구분을 위한 다른 테두리 색상 (빨간색) */
-    flex-shrink: 0;
-    aspect-ratio: 16 / 1.35; /* 메인 캔버스 높이의 약 15% 비율 */
-}
-
-/* 메인 게임 캔버스 */
-#gameCanvas {
     flex-grow: 1;
-    aspect-ratio: 16 / 9;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
 }
 
-/* ✨ HTML 전투 시작 버튼 스타일 */
+#gameCanvas {
+    border: 2px solid #fff;
+    background-color: #000;
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+#bottomUiContainer {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    flex-shrink: 0;
+    padding: 10px 0;
+}
+
+#combatLogCanvas {
+    border: 2px solid #f00;
+    width: 80%;
+    max-width: 1280px;
+    height: 120px;
+    margin-bottom: 10px;
+}
+
 .game-button {
     background-color: darkgreen;
     color: white;
-    padding: 15px 30px;
+    padding: 10px 25px;
     border: none;
     border-radius: 5px;
     cursor: pointer;
-    font-size: 24px;
-    position: absolute;
-    bottom: 10px;
-    left: 50%;
-    transform: translateX(-50%);
+    font-size: 20px;
     z-index: 99;
 }
 


### PR DESCRIPTION
## Summary
- preload essential assets in `GameEngine` initialization
- route battle startup logic through `BattleEngine`
- pass `BattleLogManager` into `CompatibilityManager`
- restructure HTML layout for bottom UI area
- update CSS for new layout
- suppress noisy grid debug logging
- refine getter for battle log manager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878637fc3a0832793547ce09cd4f37e