### PR TITLE
Fix drawing context use in GameEngine

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -188,13 +188,7 @@ export class GameEngine {
             console.log(`%c[System Health] GameEngine is drawing...`, 'color: #888;');
         }
 
-        const drawableServices = this.injector.getAllDrawable();
         this.renderEngine.draw();
-        for (const service of drawableServices) {
-            if (service !== this.renderEngine) {
-                service.draw && service.draw();
-            }
-        }
     }
 
     start() {


### PR DESCRIPTION
## Summary
- remove unused draw loop in `GameEngine` so managers don't draw without a context

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68787106c8f48327a34ee3b126fecb27