### PR TITLE
Fix BattleSimulationManager missing logic manager

### DIFF
--- a/js/engines/BattleEngine.js
+++ b/js/engines/BattleEngine.js
@@ -36,6 +36,7 @@ export class BattleEngine {
         const measureManager = injector.get('MeasureManager');
         const assetEngine = injector.get('AssetEngine');
         const renderEngine = injector.get('RenderEngine');
+        const logicManager = injector.get('LogicManager');
 
         const idManager = assetEngine.getIdManager();
         const assetLoaderManager = assetEngine.getAssetLoaderManager();
@@ -54,7 +55,7 @@ export class BattleEngine {
             measureManager,
             assetLoaderManager,
             idManager,
-            null,
+            logicManager,
             animationManager,
             this.valorEngine,
             this.aiEngine


### PR DESCRIPTION
## Summary
- pass LogicManager into `BattleSimulationManager` when creating the battle engine so rendering logic can read scene dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878747c47f4832795f1edcd63218b57