### PR TITLE
Fix test scripts missing async

### DIFF
--- a/tests/unit/classAIManagerUnitTests.js
+++ b/tests/unit/classAIManagerUnitTests.js
@@ -2,7 +2,7 @@
 
 import { ClassAIManager } from '../../js/managers/ClassAIManager.js';
 
-export function runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager) {
+export async function runClassAIManagerUnitTests(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager) {
     console.log("--- ClassAIManager Unit Test Start ---");
 
     let testCount = 0;

--- a/tests/unit/delayEngineUnitTests.js
+++ b/tests/unit/delayEngineUnitTests.js
@@ -2,7 +2,7 @@
 
 import { DelayEngine } from '../../js/managers/DelayEngine.js';
 
-export function runDelayEngineUnitTests() {
+export async function runDelayEngineUnitTests() {
     console.log("--- DelayEngine Unit Test Start ---");
 
     let testCount = 0;

--- a/tests/unit/detailInfoManagerUnitTests.js
+++ b/tests/unit/detailInfoManagerUnitTests.js
@@ -8,7 +8,7 @@ import { HeroEngine } from '../../js/managers/HeroEngine.js'; // HeroEngine 임�
 import { IdManager } from '../../js/managers/IdManager.js'; // IdManager 임포트
 import { AnimationManager } from '../../js/managers/AnimationManager.js'; // AnimationManager도 필요
 
-export function runDetailInfoManagerUnitTests() {
+export async function runDetailInfoManagerUnitTests() {
     console.log("--- DetailInfoManager Unit Test Start ---");
 
     let testCount = 0;

--- a/tests/unit/heroEngineUnitTests.js
+++ b/tests/unit/heroEngineUnitTests.js
@@ -2,7 +2,7 @@
 
 import { HeroEngine } from '../../js/managers/HeroEngine.js';
 
-export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine, diceBotManager) {
+export async function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine, diceBotManager) {
     console.log("--- HeroEngine Unit Test Start ---");
 
     let testCount = 0;

--- a/tests/unit/movingManagerUnitTests.js
+++ b/tests/unit/movingManagerUnitTests.js
@@ -3,7 +3,7 @@
 import { MovingManager } from '../../js/managers/MovingManager.js';
 import { GAME_DEBUG_MODE } from '../../js/constants.js'; // 디버그 모드 상수 임포트
 
-export function runMovingManagerUnitTests() {
+export async function runMovingManagerUnitTests() {
     if (GAME_DEBUG_MODE) console.log("--- MovingManager Unit Test Start ---");
 
     let testCount = 0;

--- a/tests/unit/skillIconManagerUnitTests.js
+++ b/tests/unit/skillIconManagerUnitTests.js
@@ -3,7 +3,7 @@
 import { SkillIconManager } from '../../js/managers/SkillIconManager.js';
 import { GAME_DEBUG_MODE } from '../../js/constants.js';
 
-export function runSkillIconManagerUnitTests(assetLoaderManager, idManager) {
+export async function runSkillIconManagerUnitTests(assetLoaderManager, idManager) {
     console.log("--- SkillIconManager Unit Test Start ---");
 
     let testCount = 0;

--- a/tests/unit/tagManagerUnitTests.js
+++ b/tests/unit/tagManagerUnitTests.js
@@ -1,6 +1,6 @@
 import { TagManager } from '../../js/managers/TagManager.js';
 
-export function runTagManagerUnitTests(idManager) {
+export async function runTagManagerUnitTests(idManager) {
     console.log("--- TagManager Unit Test Start ---");
 
     let testCount = 0;

--- a/tests/unit/timingEngineUnitTests.js
+++ b/tests/unit/timingEngineUnitTests.js
@@ -3,7 +3,7 @@
 import { TimingEngine } from '../../js/managers/TimingEngine.js';
 import { DelayEngine } from '../../js/managers/DelayEngine.js';
 
-export function runTimingEngineUnitTests() {
+export async function runTimingEngineUnitTests() {
     console.log("--- TimingEngine Unit Test Start ---");
 
     let testCount = 0;

--- a/tests/unit/turnEngineUnitTests.js
+++ b/tests/unit/turnEngineUnitTests.js
@@ -2,7 +2,7 @@
 
 import { TurnEngine } from '../../js/managers/TurnEngine.js';
 
-export function runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager) {
+export async function runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager) {
     console.log("--- TurnEngine Unit Test Start ---");
 
     let testCount = 0;

--- a/tests/unit/warriorSkillsAIUnitTests.js
+++ b/tests/unit/warriorSkillsAIUnitTests.js
@@ -4,7 +4,7 @@ import { WarriorSkillsAI } from '../../js/managers/warriorSkillsAI.js';
 import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 import { GAME_EVENTS, ATTACK_TYPES, GAME_DEBUG_MODE } from '../../js/constants.js'; // ✨ GAME_DEBUG_MODE 임포트
 
-export function runWarriorSkillsAIUnitTests() {
+export async function runWarriorSkillsAIUnitTests() {
     if (GAME_DEBUG_MODE) console.log("--- WarriorSkillsAI Unit Test Start ---");
 
     let testCount = 0;


### PR DESCRIPTION
## Summary
- fix `await` syntax errors by marking unit test runners as async

## Testing
- `npm test`
- `node tests/index.js`

------
https://chatgpt.com/codex/tasks/task_e_687878e286ec8327a746104904ebd07f