### PR TITLE
Improve battle log orientation

### DIFF
--- a/context/decisions.md
+++ b/context/decisions.md
@@ -1,0 +1,2 @@
+## Key Decisions
+- Battle log orientation should default to 'top' but be configurable.

--- a/context/insights.md
+++ b/context/insights.md
@@ -1,0 +1,2 @@
+## Insights
+- Displaying logs from the bottom improves UX for chat-style logs.

--- a/context/schema.md
+++ b/context/schema.md
@@ -1,0 +1,2 @@
+## Data Structures
+- BattleLogManager now includes `orientation` property ('top' or 'bottom').

--- a/context/state.md
+++ b/context/state.md
@@ -1,0 +1,3 @@
+## Current Task
+- Added bottom orientation feature to BattleLogManager
+- Created tests for orientation change

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -82,6 +82,8 @@ export class GameEngine {
 
         const combatLogCanvas = document.getElementById('combatLogCanvas');
         this.battleLogManager = new BattleLogManager(combatLogCanvas, this.eventManager, this.measureManager);
+        // 전투 로그는 화면 하단에서 최신 메시지가 쌓이도록 설정
+        this.battleLogManager.setOrientation('bottom');
         injector.register(this.battleLogManager);
 
         this.compatibilityManager = new CompatibilityManager(

--- a/js/managers/BattleLogManager.js
+++ b/js/managers/BattleLogManager.js
@@ -14,6 +14,8 @@ export class BattleLogManager {
         this.pixelRatio = window.devicePixelRatio || 1;
 
         this.logMessages = [];
+        // 로그 출력 방향 (top|bottom)
+        this.orientation = 'top';
         
         // 초기 내부 해상도 설정 후 로그 치수 재계산
         this.resizeCanvas();
@@ -92,6 +94,15 @@ export class BattleLogManager {
         console.log(`[BattleLog] ${message}`);
     }
 
+    /**
+     * 로그 출력 방향을 설정합니다. 기본값은 'top'이며 'bottom'을 주면
+     * 최신 로그가 아래쪽에서부터 표시됩니다.
+     * @param {'top'|'bottom'} orientation
+     */
+    setOrientation(orientation) {
+        this.orientation = orientation === 'bottom' ? 'bottom' : 'top';
+    }
+
     draw(ctx) {
         ctx.clearRect(0, 0, this.canvas.width / this.pixelRatio, this.canvas.height / this.pixelRatio);
         ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
@@ -101,10 +112,19 @@ export class BattleLogManager {
         ctx.font = `${Math.floor(this.lineHeight * 0.8)}px Arial`; // ✨ 폰트 크기 동적 조정 (줄 높이의 80%)
         ctx.textBaseline = 'top';
 
-        for (let i = 0; i < this.logMessages.length; i++) {
-            const message = this.logMessages[i];
-            const y = this.padding + i * this.lineHeight;
-            ctx.fillText(message, this.padding, y);
+        if (this.orientation === 'bottom') {
+            let startY = (this.canvas.height / this.pixelRatio) - this.padding - this.lineHeight;
+            for (let i = this.logMessages.length - 1; i >= 0; i--) {
+                const message = this.logMessages[i];
+                const y = startY - (this.logMessages.length - 1 - i) * this.lineHeight;
+                ctx.fillText(message, this.padding, y);
+            }
+        } else {
+            for (let i = 0; i < this.logMessages.length; i++) {
+                const message = this.logMessages[i];
+                const y = this.padding + i * this.lineHeight;
+                ctx.fillText(message, this.padding, y);
+            }
         }
     }
 }

--- a/tests/unit/battleLogManagerUnitTests.js
+++ b/tests/unit/battleLogManagerUnitTests.js
@@ -99,5 +99,24 @@ export function runBattleLogManagerUnitTests(eventManager, measureManager) {
         console.error("BattleLogManager: Error during draw. [FAIL]", e);
     }
 
+    // 테스트 5: 출력 방향 설정 기능 확인
+    testCount++;
+    try {
+        const logManager = new BattleLogManager(mockCanvas, eventManager, measureManager);
+        if (logManager.orientation === 'top') {
+            logManager.setOrientation('bottom');
+            if (logManager.orientation === 'bottom') {
+                console.log('BattleLogManager: Orientation change succeeded. [PASS]');
+                passCount++;
+            } else {
+                console.error('BattleLogManager: Orientation not updated. [FAIL]');
+            }
+        } else {
+            console.error('BattleLogManager: Default orientation incorrect. [FAIL]');
+        }
+    } catch (e) {
+        console.error('BattleLogManager: Error changing orientation. [FAIL]', e);
+    }
+
     console.log(`--- BattleLogManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
 }


### PR DESCRIPTION
## Summary
- add orientation property to `BattleLogManager`
- allow choosing bottom-up log display and use it in `GameEngine`
- cover orientation change in unit tests
- store project context files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68787a9f98188327b50c9d59ff6c634f