### PR TITLE
Fix TurnEngine AI registration and safe target lookup

### DIFF
--- a/js/ai/nodes/UnitActionNodes.js
+++ b/js/ai/nodes/UnitActionNodes.js
@@ -11,7 +11,18 @@ import { GAME_DEBUG_MODE } from '../../constants.js';
 export class FindTargetNode extends Node {
     async evaluate(blackboard) {
         const unit = blackboard.getData('self');
-        const { targetingManager } = blackboard.getData('managers');
+        // managers 객체를 통해 안전하게 targetingManager를 가져옵니다.
+        const managers = blackboard.getData('managers') || {};
+        const { targetingManager } = managers;
+
+        // targetingManager가 존재하는지 확인 후 getLowestHpUnit를 호출합니다.
+        if (!targetingManager) {
+            if (GAME_DEBUG_MODE) {
+                console.error(`  [BT-FAILURE] ${unit.name}: TargetingManager를 찾을 수 없습니다.`);
+            }
+            return NodeState.FAILURE;
+        }
+
         const target = targetingManager.getLowestHpUnit('enemy');
 
         if (target) {

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -112,9 +112,8 @@ export class TurnEngine {
         const allUnits = this.battleSimulationManager.unitsOnGrid;
         this.aiEngine.cleanup();
         allUnits.forEach(unit => {
-            if (unit.type === ATTACK_TYPES.ENEMY) {
-                this.aiEngine.registerUnit(unit, allUnits);
-            }
+            // 적 유닛만 등록하던 기존 로직을 모든 유닛 등록으로 확장합니다.
+            this.aiEngine.registerUnit(unit, allUnits);
         });
 
         this.statusEffectManager.turnCountManager.clearAllEffects();


### PR DESCRIPTION
## Summary
- register every unit with `AIEngine` at the start of battle
- check for `targetingManager` in `FindTargetNode` to avoid runtime errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68788d208a308327ae042f902624b3e3