### PR TITLE
Fix monster spawn crash and add undead stats

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -35,7 +35,22 @@ export const CLASSES = {
         description: '다수로 몰려오는 기본적인 언데드 적.',
         skills: ['skill_melee_attack'],
         moveRange: 2, // 해골의 이동 거리(예시)
-        tags: ['근접', '언데드', '적_클래스'] // ✨ 태그 추가
+        tags: ['근접', '언데드', '적_클래스'], // ✨ 태그 추가
+        // 기본 능력치. 몬스터 스폰 시 참조됩니다.
+        baseStats: {
+            hp: 60,
+            attack: 10,
+            defense: 4,
+            speed: 25,
+            valor: 0,
+            strength: 8,
+            endurance: 6,
+            agility: 8,
+            intelligence: 4,
+            wisdom: 4,
+            luck: 5,
+            weight: 8
+        }
     },
     // ✨ 좀비 클래스 추가
     ZOMBIE: {
@@ -45,7 +60,22 @@ export const CLASSES = {
         description: '느릿느릿 움직이는 언데드.',
         skills: ['skill_melee_attack'],
         moveRange: 2,
-        tags: ['근접', '언데드', '적_클래스']
+        tags: ['근접', '언데드', '적_클래스'],
+        // 기본 능력치 정의
+        baseStats: {
+            hp: 80,
+            attack: 15,
+            defense: 5,
+            speed: 30,
+            valor: 10,
+            strength: 10,
+            endurance: 8,
+            agility: 12,
+            intelligence: 5,
+            wisdom: 5,
+            luck: 15,
+            weight: 10
+        }
     },
     // ✨ 전사 상위 클래스 추가
     WARRIOR_VALIANT: {

--- a/js/managers/MonsterSpawnManager.js
+++ b/js/managers/MonsterSpawnManager.js
@@ -27,6 +27,11 @@ export class MonsterSpawnManager {
         const zombieClassData = await this.idManager.get('class_zombie');
         const zombieImage = this.assetLoaderManager.getImage('sprite_zombie_default');
 
+        if (!zombieClassData || !zombieClassData.baseStats) {
+            console.error('[MonsterSpawnManager] Invalid zombie class data.');
+            return;
+        }
+
         const zombieData = currentStage.monsters.find(m => m.classId === 'class_zombie');
         if (zombieData) {
             const formation = currentStage.formations[zombieData.formation] || [];


### PR DESCRIPTION
## Summary
- add base stat definitions for skeleton and zombie classes
- guard MonsterSpawnManager from missing class data

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878a69078888327a0bf0d9d0116671f