### PR TITLE
Update executeSkillAI targeting

### DIFF
--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -1,6 +1,5 @@
 // js/managers/ClassAIManager.js
 
-import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 import { GAME_DEBUG_MODE } from '../constants.js';
 
 export class ClassAIManager {
@@ -77,9 +76,21 @@ export class ClassAIManager {
         const aiFunction = this.warriorSkillsAI[skillData.aiFunction];
         if (typeof aiFunction === 'function') {
             let targetUnit = null;
-            if (skillData.id === WARRIOR_SKILLS.CHARGE.id) {
+
+            // ✨ 수정된 부분 시작
+            // 스킬 타입이 'active'인 경우, 일반적으로 적을 대상으로 합니다.
+            if (skillData.type === 'active') {
+                // 가장 체력이 낮은 적을 우선 타겟으로 설정합니다.
                 targetUnit = this.targetingManager.getLowestHpUnit('enemy');
+
+                // 만약 타겟을 찾지 못했다면, 스킬 사용을 취소하고 경고를 출력합니다.
+                if (!targetUnit) {
+                    if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] ${userUnit.name} wanted to use ${skillData.name}, but no valid enemy target was found.`);
+                    return;
+                }
             }
+            // 'buff' 타입의 스킬(예: 전투의 외침)은 대상이 필요 없으므로 targetUnit이 null인 상태로 진행됩니다.
+            // ✨ 수정된 부분 끝
 
             await aiFunction.call(this.warriorSkillsAI, userUnit, targetUnit, skillData);
         } else {


### PR DESCRIPTION
## Summary
- refine ClassAIManager's executeSkillAI to auto-target lowest HP enemies for active skills and cancel when no target is found
- remove unused warrior skills import

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6878c5e114f48327b05cf2e9234f4d6b