### PR TITLE
Introduce JudgementManager and streamline logging

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -38,6 +38,8 @@ import { TurnOrderManager } from './managers/TurnOrderManager.js'; // ✨ 새롭
 import { ClassAIManager } from './managers/ClassAIManager.js';   // ✨ 새롭게 추가
 import { BasicAIManager } from './managers/BasicAIManager.js'; // ✨ 새롭게 추가
 import { TargetingManager } from './managers/TargetingManager.js'; // ✨ TargetingManager 추가
+import { PositionManager } from './managers/PositionManager.js'; // ✨ PositionManager 추가
+import { JudgementManager } from './managers/JudgementManager.js'; // JudgementManager 임포트
 import { ValorEngine } from './managers/ValorEngine.js';   // ✨ ValorEngine 추가
 import { WeightEngine } from './managers/WeightEngine.js'; // ✨ WeightEngine 추가
 import { StatManager } from './managers/StatManager.js'; // ✨ StatManager 추가
@@ -94,6 +96,8 @@ export class GameEngine {
         this.eventManager = new EventManager();
         // ✨ CRITICAL_ERROR 이벤트 구독
         this.eventManager.subscribe(GAME_EVENTS.CRITICAL_ERROR, this._handleCriticalError.bind(this));
+        // JudgementManager는 EventManager 이후 초기화
+        this.judgementManager = new JudgementManager(this.eventManager);
 
         this.guardianManager = new GuardianManager();
         this.measureManager = new MeasureManager();
@@ -363,8 +367,12 @@ export class GameEngine {
             this.measureManager
         );
 
-        // ✨ BasicAIManager 초기화
-        this.basicAIManager = new BasicAIManager(this.battleSimulationManager);
+        // ✨ 신규 매니저들 초기화 (BattleSimulationManager 이후에)
+        this.targetingManager = new TargetingManager(this.battleSimulationManager);
+        this.positionManager = new PositionManager(this.battleSimulationManager);
+
+        // ✨ BasicAIManager에 신규 매니저들 주입
+        this.basicAIManager = new BasicAIManager(this.targetingManager, this.positionManager);
 
         // AI 와 턴 진행 관련 매니저들
         this.turnOrderManager = new TurnOrderManager(
@@ -372,8 +380,6 @@ export class GameEngine {
             this.battleSimulationManager,
             this.weightEngine // ✨ weightEngine 추가
         );
-        // 먼저 TargetingManager를 초기화
-        this.targetingManager = new TargetingManager(this.battleSimulationManager);
         // ClassAIManager에 추가 매니저 전달
         this.classAIManager = new ClassAIManager(
             this.idManager,
@@ -382,7 +388,7 @@ export class GameEngine {
             this.basicAIManager,
             this.warriorSkillsAI,
             this.diceEngine,
-            this.targetingManager,
+            this.targetingManager, // 이미 주입되고 있었는지 확인
             this.diceBotEngine
         );
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -25,6 +25,7 @@ export const GAME_EVENTS = {
     CANVAS_MOUSE_MOVED: 'canvasMouseMoved', // ✨ 마우스 이동 이벤트 추가
     CRITICAL_ERROR: 'criticalError', // ✨ 심각한 오류 발생 시 발행될 이벤트
     ASSET_LOAD_PROGRESS: 'assetLoadProgress', // ✨ 에셋 로딩 진행 이벤트 추가
+    AI_ACTION_DECIDED: 'aiActionDecided', // JudgementManager에서 사용
     ASSETS_LOADED: 'assetsLoaded'             // ✨ 모든 에셋 로딩 완료 이벤트 추가
 };
 

--- a/js/managers/BattleGridManager.js
+++ b/js/managers/BattleGridManager.js
@@ -1,8 +1,9 @@
 // js/managers/BattleGridManager.js
+import { GAME_DEBUG_MODE } from '../constants.js';
 
 export class BattleGridManager {
     constructor(measureManager, logicManager) {
-        console.log("\uD83D\uDCDC BattleGridManager initialized. Ready to draw the battlefield grid. \uD83D\uDCDC");
+        if (GAME_DEBUG_MODE) console.log("\uD83D\uDCDC BattleGridManager initialized. Ready to draw the battlefield grid. \uD83D\uDCDC");
         this.measureManager = measureManager;
         this.logicManager = logicManager;
         this.gridRows = 9;  // 16:9 비율에 맞춘 행 수
@@ -39,8 +40,9 @@ export class BattleGridManager {
         const gridOffsetX = (canvasWidth - totalGridWidth) / 2;
         const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
-        console.log(`[BattleGridManager Debug] Drawing Grid Parameters (in draw()): \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\n            Scene Content (Logical): ${sceneContentDimensions.width}x${sceneContentDimensions.height}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}\n            Total Grid Render Size (Logical): ${totalGridWidth.toFixed(2)}x${totalGridHeight.toFixed(2)}`
-        );
+        if (GAME_DEBUG_MODE) {
+            console.log(`[BattleGridManager Debug] Drawing Grid Parameters (in draw()): \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\nScene Content (Logical): ${sceneContentDimensions.width}x${sceneContentDimensions.height}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}\n            Total Grid Render Size (Logical): ${totalGridWidth.toFixed(2)}x${totalGridHeight.toFixed(2)}`);
+        }
 
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)';
         ctx.lineWidth = 1;
@@ -48,7 +50,7 @@ export class BattleGridManager {
         // 세로선 그리기
         for (let i = 0; i <= this.gridCols; i++) {
             const lineX = gridOffsetX + i * effectiveTileSize;
-            console.log(`[BattleGridManager Debug] Vertical Line ${i}: X=${lineX.toFixed(2)} from Y=${gridOffsetY.toFixed(2)} to Y=${(gridOffsetY + totalGridHeight).toFixed(2)}`);
+            if (GAME_DEBUG_MODE) console.log(`[BattleGridManager Debug] Vertical Line ${i}: X=${lineX.toFixed(2)} from Y=${gridOffsetY.toFixed(2)} to Y=${(gridOffsetY + totalGridHeight).toFixed(2)}`);
             ctx.beginPath();
             ctx.moveTo(lineX, gridOffsetY);
             ctx.lineTo(lineX, gridOffsetY + totalGridHeight);
@@ -58,7 +60,7 @@ export class BattleGridManager {
         // 가로선 그리기
         for (let i = 0; i <= this.gridRows; i++) {
             const lineY = gridOffsetY + i * effectiveTileSize;
-            console.log(`[BattleGridManager Debug] Horizontal Line ${i}: Y=${lineY.toFixed(2)} from X=${gridOffsetX.toFixed(2)} to X=${(gridOffsetX + totalGridWidth).toFixed(2)}`);
+            if (GAME_DEBUG_MODE) console.log(`[BattleGridManager Debug] Horizontal Line ${i}: Y=${lineY.toFixed(2)} from X=${gridOffsetX.toFixed(2)} to X=${(gridOffsetX + totalGridWidth).toFixed(2)}`);
             ctx.beginPath();
             ctx.moveTo(gridOffsetX, lineY);
             ctx.lineTo(gridOffsetX + totalGridWidth, lineY);
@@ -66,7 +68,7 @@ export class BattleGridManager {
         }
 
         // 그리드 영역 테두리 (확인용)
-        console.log(`[BattleGridManager Debug] Border Rect: X=${gridOffsetX.toFixed(2)}, Y=${gridOffsetY.toFixed(2)}, W=${totalGridWidth.toFixed(2)}, H=${totalGridHeight.toFixed(2)}`);
+        if (GAME_DEBUG_MODE) console.log(`[BattleGridManager Debug] Border Rect: X=${gridOffsetX.toFixed(2)}, Y=${gridOffsetY.toFixed(2)}, W=${totalGridWidth.toFixed(2)}, H=${totalGridHeight.toFixed(2)}`);
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
         ctx.lineWidth = 2;
         ctx.strokeRect(gridOffsetX, gridOffsetY, totalGridWidth, totalGridHeight);

--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -37,14 +37,9 @@ export class ClassAIManager {
         }
 
         if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] No skill was chosen for ${unit.name}, proceeding with basic AI.`);
-        switch (unitClass.id) {
-            case 'class_warrior':
-                return this._getWarriorAction(unit, allUnits, unitClass);
-            default:
-                const defaultMoveRange = unitClass.moveRange || 1;
-                const defaultAttackRange = unitClass.attackRange || 1;
-                return this.basicAIManager.determineMoveAndTarget(unit, allUnits, defaultMoveRange, defaultAttackRange);
-        }
+        const defaultMoveRange = unit.baseStats.moveRange || 1;
+        const defaultAttackRange = unit.baseStats.attackRange || 1;
+        return this.basicAIManager.determineMoveAndTarget(unit, defaultMoveRange, defaultAttackRange);
     }
 
     async decideSkillToUse(unit) {
@@ -67,7 +62,7 @@ export class ClassAIManager {
 
         const result = this.diceBotEngine.pickWeightedRandom(skillTable);
 
-        console.log(`[ClassAIManager Debug] DiceBot picked skill for ${unit.name}: ${result ? result.item.name : 'None'}`);
+        if (GAME_DEBUG_MODE) console.log(`[ClassAIManager Debug] DiceBot picked skill for ${unit.name}: ${result ? result.item.name : 'None'}`);
 
         return result ? result.item : null;
     }
@@ -110,12 +105,10 @@ export class ClassAIManager {
      * @param {object} warriorClassData
      * @returns {{actionType: string, targetId?: string, moveTargetX?: number, moveTargetY?: number}}
      */
-    _getWarriorAction(warriorUnit, allUnits, warriorClassData) {
+    _getWarriorAction(warriorUnit, warriorClassData) {
         const moveRange = warriorClassData.moveRange || 1;
         const attackRange = 1;
 
-        const action = this.basicAIManager.determineMoveAndTarget(warriorUnit, allUnits, moveRange, attackRange);
-
-        return action;
+        return this.basicAIManager.determineMoveAndTarget(warriorUnit, moveRange, attackRange);
     }
 }

--- a/js/managers/DiceEngine.js
+++ b/js/managers/DiceEngine.js
@@ -1,8 +1,9 @@
 // js/managers/DiceEngine.js
+import { GAME_DEBUG_MODE } from '../constants.js';
 
 export class DiceEngine {
     constructor() {
-        console.log("\uD83C\uDFB2 DiceEngine initialized. Ready to roll all random elements. \uD83C\uDFB2");
+        if (GAME_DEBUG_MODE) console.log("\uD83C\uDFB2 DiceEngine initialized. Ready to roll all random elements. \uD83C\uDFB2");
         // 이 엔진은 순수하게 무작위성을 제공하는 메서드를 포함합니다.
     }
 
@@ -13,11 +14,11 @@ export class DiceEngine {
      */
     rollD(sides) {
         if (sides <= 0) {
-            console.warn("[DiceEngine] Cannot roll a dice with 0 or negative sides. Returning 1.");
+            if (GAME_DEBUG_MODE) console.warn("[DiceEngine] Cannot roll a dice with 0 or negative sides. Returning 1.");
             return 1;
         }
         const result = Math.floor(Math.random() * sides) + 1;
-        console.log(`[DiceEngine] Rolled d${sides}: ${result}`);
+        if (GAME_DEBUG_MODE) console.log(`[DiceEngine] Rolled d${sides}: ${result}`);
         return result;
     }
 

--- a/js/managers/EventManager.js
+++ b/js/managers/EventManager.js
@@ -1,7 +1,7 @@
 // js/managers/EventManager.js
 
 // ✨ 상수 파일 임포트
-import { GAME_EVENTS, ATTACK_TYPES } from '../constants.js';
+import { GAME_EVENTS, ATTACK_TYPES, GAME_DEBUG_MODE } from '../constants.js';
 
 export class EventManager {
     constructor() {
@@ -24,7 +24,7 @@ export class EventManager {
             });
         };
 
-        console.log("[EventManager] Initialized with Web Worker.");
+        if (GAME_DEBUG_MODE) console.log("[EventManager] Initialized with Web Worker.");
     }
 
     /**
@@ -39,14 +39,14 @@ export class EventManager {
             this.dispatch(eventName, data);
         } else if (type === 'SKILL_TRIGGERED') {
             // Worker의 '작은 엔진'이 스킬 발동을 요청함
-            console.log(`[EventManager] Worker requested skill: ${skillName}`);
+            if (GAME_DEBUG_MODE) console.log(`[EventManager] Worker requested skill: ${skillName}`);
             // TODO: 실제 게임에서는 이 요청을 CombatEngine이나 StatSystem 등으로 전달하여
             // 해당 스킬의 효과를 적용해야 합니다.
             // 임시로 콘솔에 출력
             if (skillName === '흡혈') {
-                console.log(`[EventManager] Unit ${targetUnitId} 흡혈 ${amount} 만큼 발동!`);
+                if (GAME_DEBUG_MODE) console.log(`[EventManager] Unit ${targetUnitId} 흡혈 ${amount} 만큼 발동!`);
             } else if (skillName === '광역 공포') {
-                console.log(`[EventManager] ${sourceUnitId} 사망으로 인한 광역 공포(${radius} 범위) 발동!`);
+                if (GAME_DEBUG_MODE) console.log(`[EventManager] ${sourceUnitId} 사망으로 인한 광역 공포(${radius} 범위) 발동!`);
             }
             // 이 시점에서 다시 이벤트를 발생시킬 수도 있습니다.
             this.emit(GAME_EVENTS.SKILL_EXECUTED, { skillName, targetUnitId, amount, sourceUnitId, radius }); // ✨ 상수 사용
@@ -74,7 +74,7 @@ export class EventManager {
             this.subscribers.set(eventName, []);
         }
         this.subscribers.get(eventName).push(callback);
-        console.log(`[EventManager] Subscribed to event: ${eventName}`);
+        if (GAME_DEBUG_MODE) console.log(`[EventManager] Subscribed to event: ${eventName}`);
     }
 
     /**
@@ -94,7 +94,7 @@ export class EventManager {
     terminateWorker() {
         if (this.worker) {
             this.worker.terminate();
-            console.log("[EventManager] Web Worker terminated.");
+            if (GAME_DEBUG_MODE) console.log("[EventManager] Web Worker terminated.");
         }
     }
 

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -1,13 +1,13 @@
 // js/managers/HeroManager.js
 
-import { ATTACK_TYPES } from '../constants.js';
+import { ATTACK_TYPES, GAME_DEBUG_MODE } from '../constants.js';
 import { UNITS } from '../../data/unit.js';
 import { CLASSES } from '../../data/class.js';
 import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 
 export class HeroManager {
     constructor(idManager, diceEngine, assetLoaderManager, battleSimulationManager, unitSpriteEngine, diceBotEngine) {
-        console.log("\u2728 HeroManager initialized. Ready to create legendary heroes. \u2728");
+        if (GAME_DEBUG_MODE) console.log("\u2728 HeroManager initialized. Ready to create legendary heroes. \u2728");
         this.idManager = idManager;
         this.diceEngine = diceEngine;
         this.assetLoaderManager = assetLoaderManager;
@@ -26,7 +26,7 @@ export class HeroManager {
      * @returns {Promise<object[]>} 생성된 영웅 데이터 배열
      */
     async createWarriors(count) {
-        console.log(`[HeroManager] Creating data for ${count} new warriors...`);
+        if (GAME_DEBUG_MODE) console.log(`[HeroManager] Creating data for ${count} new warriors...`);
         const warriorClassData = await this.idManager.get(CLASSES.WARRIOR.id);
         const warriorImage = this.assetLoaderManager.getImage(UNITS.WARRIOR.spriteId);
 
@@ -69,7 +69,7 @@ export class HeroManager {
             });
 
             createdHeroes.push(heroUnitData);
-            console.log(`[HeroManager] Created data for warrior: ${heroUnitData.name}`);
+            if (GAME_DEBUG_MODE) console.log(`[HeroManager] Created data for warrior: ${heroUnitData.name}`);
         }
         return createdHeroes;
     }

--- a/js/managers/JudgementManager.js
+++ b/js/managers/JudgementManager.js
@@ -1,0 +1,73 @@
+import { GAME_EVENTS, GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * 전투의 규칙과 흐름을 감시하고, 룰 위반 시 경고를 출력하는 심판 매니저입니다.
+ */
+export class JudgementManager {
+    constructor(eventManager) {
+        if (!GAME_DEBUG_MODE) return; // 디버그 모드가 아니면 동작하지 않음
+
+        console.log("⚖️ JudgementManager initialized. The court is now in session. ⚖️");
+        this.eventManager = eventManager;
+
+        this.currentTurn = 0;
+        this.activeUnit = null;
+        this.expectedAction = null;
+        this.actualActionTaken = false;
+
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        this.eventManager.subscribe(GAME_EVENTS.TURN_START, data => {
+            this.currentTurn = data.turn;
+        });
+
+        this.eventManager.subscribe(GAME_EVENTS.UNIT_TURN_START, data => {
+            this.activeUnit = { id: data.unitId, name: data.unitName };
+            this.expectedAction = null;
+            this.actualActionTaken = false;
+            if (GAME_DEBUG_MODE) console.log(`[JudgementManager] Watching turn for: ${this.activeUnit.name}`);
+        });
+
+        this.eventManager.subscribe(GAME_EVENTS.AI_ACTION_DECIDED, data => {
+            if (this.activeUnit && this.activeUnit.id === data.unitId) {
+                this.expectedAction = data.decidedAction;
+                if (GAME_DEBUG_MODE) console.log(`[JudgementManager] Expected action for ${this.activeUnit.name}:`, this.expectedAction);
+            }
+        });
+        
+        // 유닛의 실제 행동을 감지
+        this.eventManager.subscribe(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, data => {
+            if (this.activeUnit && this.activeUnit.id === data.attackerId) {
+                this.actualActionTaken = true;
+            }
+        });
+        this.eventManager.subscribe(GAME_EVENTS.SKILL_EXECUTED, data => {
+             if (this.activeUnit && this.activeUnit.id === data.userId) {
+                this.actualActionTaken = true;
+            }
+        });
+
+        this.eventManager.subscribe(GAME_EVENTS.UNIT_TURN_END, this._judgeTurnAction.bind(this));
+    }
+
+    _judgeTurnAction(data) {
+        if (!this.activeUnit || this.activeUnit.id !== data.unitId) return;
+
+        // 시나리오 1: AI는 행동을 결정했지만, 실제로는 아무 행동도 하지 않았을 때
+        if (this.expectedAction && !this.actualActionTaken) {
+            console.warn(
+                `%c⚖️ JUDGEMENT ⚖️: Rule Violation Detected!`,
+                'color: yellow; font-size: 14px; font-weight: bold;'
+            );
+            console.warn(`- Unit: ${this.activeUnit.name} (ID: ${this.activeUnit.id})`);
+            console.warn(`- Turn: ${this.currentTurn}`);
+            console.warn(`- Violation: 'Inaction'. The AI decided on an action but no corresponding action was executed.`);
+            console.warn(`- Expected Action:`, this.expectedAction);
+            console.warn(`- Reason: This often happens if the AI's chosen target becomes invalid (e.g., dies) before the action executes, or if there's a logic bug in the skill's execution flow that prevents it from completing.`);
+        }
+
+        // 앞으로 더 많은 규칙을 여기에 추가할 수 있습니다.
+    }
+}

--- a/js/managers/PositionManager.js
+++ b/js/managers/PositionManager.js
@@ -1,0 +1,87 @@
+// js/managers/PositionManager.js
+
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * 그리드 좌표, 경로 탐색 등 위치와 관련된 모든 계산을 담당합니다.
+ */
+export class PositionManager {
+    constructor(battleSimulationManager) {
+        if (GAME_DEBUG_MODE) console.log("🗺️ PositionManager initialized. Ready for cartography and pathfinding. 🗺️");
+        this.battleSimulationManager = battleSimulationManager;
+    }
+
+    /**
+     * 목표 유닛 주변에서 공격이 가능한 모든 빈 타일의 좌표를 찾습니다.
+     * @param {object} targetUnit - 공격 대상 유닛
+     * @param {number} attackRange - 공격 사거리
+     * @returns {Array<{x: number, y: number}>} 공격 가능한 좌표 목록
+     */
+    getAttackablePositions(targetUnit, attackRange) {
+        const positions = [];
+        for (let dx = -attackRange; dx <= attackRange; dx++) {
+            for (let dy = -attackRange; dy <= attackRange; dy++) {
+                // 맨해튼 거리(직선 이동) 기반으로 사거리 계산
+                if (Math.abs(dx) + Math.abs(dy) > attackRange) continue;
+                
+                const x = targetUnit.gridX + dx;
+                const y = targetUnit.gridY + dy;
+
+                // 자기 자신 위치는 공격 위치가 아님
+                if (x === targetUnit.gridX && y === targetUnit.gridY) continue;
+
+                if (this.isInsideMap(x, y) && !this.battleSimulationManager.isTileOccupied(x, y)) {
+                    positions.push({ x, y });
+                }
+            }
+        }
+        return positions;
+    }
+
+    /**
+     * 시작점에서 도착점까지의 최단 경로를 찾습니다. (A* 알고리즘의 간소화 버전)
+     * @param {{x: number, y: number}} startPos - 시작 좌표
+     * @param {{x: number, y: number}} endPos - 도착 좌표
+     * @param {number} maxMoveRange - 최대 이동 가능 거리
+     * @returns {Array<{x: number, y: number}> | null} 경로 배열 또는 null
+     */
+    findPath(startPos, endPos, maxMoveRange) {
+        const queue = [{ x: startPos.x, y: startPos.y, path: [{x: startPos.x, y: startPos.y}], dist: 0 }];
+        const visited = new Set([`${startPos.x},${startPos.y}`]);
+        const directions = [[0, 1], [0, -1], [1, 0], [-1, 0]]; // 4방향 이동
+
+        while (queue.length > 0) {
+            const current = queue.shift();
+
+            if (current.dist >= maxMoveRange) continue;
+
+            for (const [dx, dy] of directions) {
+                const nextX = current.x + dx;
+                const nextY = current.y + dy;
+                const key = `${nextX},${nextY}`;
+
+                if (nextX === endPos.x && nextY === endPos.y) {
+                    return current.path.concat({ x: nextX, y: nextY });
+                }
+
+                if (this.isInsideMap(nextX, nextY) && !visited.has(key) && !this.battleSimulationManager.isTileOccupied(nextX, nextY)) {
+                    visited.add(key);
+                    const newPath = current.path.concat({ x: nextX, y: nextY });
+                    queue.push({ x: nextX, y: nextY, path: newPath, dist: current.dist + 1 });
+                }
+            }
+        }
+        return null; // 경로를 찾지 못함
+    }
+
+    /**
+     * 해당 좌표가 맵 내부에 있는지 확인합니다.
+     * @param {number} x
+     * @param {number} y
+     * @returns {boolean}
+     */
+    isInsideMap(x, y) {
+        const { gridCols, gridRows } = this.battleSimulationManager;
+        return x >= 0 && x < gridCols && y >= 0 && y < gridRows;
+    }
+}

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -1,11 +1,11 @@
 // js/managers/TurnEngine.js
 
 // ✨ 상수 파일 임포트
-import { GAME_EVENTS, UI_STATES, ATTACK_TYPES } from '../constants.js';
+import { GAME_EVENTS, UI_STATES, ATTACK_TYPES, GAME_DEBUG_MODE } from '../constants.js';
 
 export class TurnEngine {
     constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager, statusEffectManager) {
-        console.log("\uD83D\uDD01 TurnEngine initialized. Ready to manage game turns. \uD83D\uDD01");
+        if (GAME_DEBUG_MODE) console.log("\uD83D\uDD01 TurnEngine initialized. Ready to manage game turns. \uD83D\uDD01");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
         this.turnOrderManager = turnOrderManager;
@@ -36,14 +36,14 @@ export class TurnEngine {
      */
     initializeTurnOrder() {
         this.turnOrder = this.turnOrderManager.calculateTurnOrder();
-        console.log("[TurnEngine] Turn order initialized:", this.turnOrder.map(unit => unit.name));
+        if (GAME_DEBUG_MODE) console.log("[TurnEngine] Turn order initialized:", this.turnOrder.map(unit => unit.name));
     }
 
     /**
      * 턴 진행을 시작합니다.
      */
     async startBattleTurns() {
-        console.log("[TurnEngine] Battle turns are starting!");
+        if (GAME_DEBUG_MODE) console.log("[TurnEngine] Battle turns are starting!");
         this.currentTurn = 0;
         this.initializeTurnOrder();
         // 전투 시작 시 모든 상태 효과 초기화
@@ -56,20 +56,20 @@ export class TurnEngine {
         const livingEnemies = this.battleSimulationManager.unitsOnGrid.filter(u => u.type === ATTACK_TYPES.ENEMY && u.currentHp > 0); // ✨ 상수 사용
 
         if (livingMercenaries.length === 0) {
-            console.log("[TurnEngine] All mercenaries defeated! Battle Over.");
+        if (GAME_DEBUG_MODE) console.log("[TurnEngine] All mercenaries defeated! Battle Over.");
             this.eventManager.emit(GAME_EVENTS.BATTLE_END, { reason: 'allMercenariesDefeated' }); // ✨ 상수 사용
             this.eventManager.setGameRunningState(false);
             return;
         }
         if (livingEnemies.length === 0) {
-            console.log("[TurnEngine] All enemies defeated! Battle Over.");
+        if (GAME_DEBUG_MODE) console.log("[TurnEngine] All enemies defeated! Battle Over.");
             this.eventManager.emit(GAME_EVENTS.BATTLE_END, { reason: 'allEnemiesDefeated' }); // ✨ 상수 사용
             this.eventManager.setGameRunningState(false);
             return;
         }
 
         this.currentTurn++;
-        console.log(`\n--- Turn ${this.currentTurn} Starts ---`);
+        if (GAME_DEBUG_MODE) console.log(`\n--- Turn ${this.currentTurn} Starts ---`);
         this.eventManager.emit(GAME_EVENTS.TURN_START, { turn: this.currentTurn }); // ✨ 상수 사용
         this.timingEngine.clearActions();
 
@@ -82,12 +82,12 @@ export class TurnEngine {
         for (let i = 0; i < currentTurnUnits.length; i++) {
             const unit = currentTurnUnits[i];
             if (unit.currentHp <= 0) {
-                console.log(`[TurnEngine] Unit ${unit.name} is already dead. Skipping turn.`);
+                if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Unit ${unit.name} is already dead. Skipping turn.`);
                 continue;
             }
 
             this.activeUnitIndex = i;
-            console.log(`[TurnEngine] Processing turn for unit: ${unit.name} (ID: ${unit.id})`);
+            if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Processing turn for unit: ${unit.name} (ID: ${unit.id})`);
             this.eventManager.emit(GAME_EVENTS.UNIT_TURN_START, { unitId: unit.id, unitName: unit.name }); // ✨ 상수 사용
             // ✨ 상태 효과 확인: 유닛의 행동 가능 여부 검사
             const activeEffects = this.statusEffectManager.getUnitActiveEffects(unit.id);
@@ -97,7 +97,7 @@ export class TurnEngine {
                 for (const [effectId, effect] of activeEffects.entries()) {
                     if (effect.effectData.effect.canAct === false) {
                         canUnitAct = false;
-                        console.log(`[TurnEngine] Unit ${unit.name} is ${effect.effectData.name} (${effectId}) and cannot act this turn.`);
+                        if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Unit ${unit.name} is ${effect.effectData.name} (${effectId}) and cannot act this turn.`);
                         break;
                     }
                 }
@@ -110,12 +110,18 @@ export class TurnEngine {
                 action = await this.classAIManager.getBasicClassAction(unit, this.battleSimulationManager.unitsOnGrid);
             }
 
+            // JudgementManager가 AI 결정을 감시할 수 있도록 알림
+            this.eventManager.emit(GAME_EVENTS.AI_ACTION_DECIDED, {
+                unitId: unit.id,
+                decidedAction: action
+            });
+
             if (action) {
                 this.timingEngine.addTimedAction(async () => {
                     if (action.actionType === 'move' || action.actionType === 'moveAndAttack') {
                         const startGridX = unit.gridX;
                         const startGridY = unit.gridY;
-                        console.log(`[TurnEngine] Unit ${unit.name} attempts to move from (${startGridX},${startGridY}) to (${action.moveTargetX}, ${action.moveTargetY}).`);
+                        if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Unit ${unit.name} attempts to move from (${startGridX},${startGridY}) to (${action.moveTargetX}, ${action.moveTargetY}).`);
 
                         const moved = this.battleSimulationManager.moveUnit(unit.id, action.moveTargetX, action.moveTargetY);
                         if (moved) {
@@ -133,7 +139,7 @@ export class TurnEngine {
                         if (action.targetId) {
                             const targetUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === action.targetId);
                             if (targetUnit && targetUnit.currentHp > 0) {
-                                console.log(`[TurnEngine] Unit ${unit.name} attacks ${targetUnit.name}!`);
+                                if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Unit ${unit.name} attacks ${targetUnit.name}!`);
                                 this.eventManager.emit(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, { // ✨ 상수 사용
                                     attackerId: unit.id,
                                     targetId: targetUnit.id,
@@ -143,16 +149,16 @@ export class TurnEngine {
                                 this.battleCalculationManager.requestDamageCalculation(unit.id, targetUnit.id, defaultAttackSkillData);
                                 await this.delayEngine.waitFor(500);
                             } else {
-                                console.log(`[TurnEngine] Target ${action.targetId} is no longer valid for attack.`);
+                                if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Target ${action.targetId} is no longer valid for attack.`);
                             }
                         }
                     } else if (action.actionType === 'skill') {
-                        console.log(`[TurnEngine] Unit ${unit.name} attempts to use skill.`);
+                        if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Unit ${unit.name} attempts to use skill.`);
                         await this.delayEngine.waitFor(800);
                     }
                 }, 10, `${unit.name}'s Primary Action`);
             } else {
-                console.log(`[TurnEngine] Unit ${unit.name} has no determined action for this turn.`);
+                if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Unit ${unit.name} has no determined action for this turn.`);
             }
 
             this.eventManager.emit(GAME_EVENTS.TURN_PHASE, { phase: 'unitActions', unitId: unit.id, turn: this.currentTurn });
@@ -170,23 +176,23 @@ export class TurnEngine {
             await callback();
         }
 
-        console.log(`--- Turn ${this.currentTurn} Ends ---\n`);
+        if (GAME_DEBUG_MODE) console.log(`--- Turn ${this.currentTurn} Ends ---\n`);
 
         await this.delayEngine.waitFor(1000);
 
         if (this.eventManager.getGameRunningState()) {
             this.nextTurn();
         } else {
-            console.log("[TurnEngine] Game is paused or ended, not proceeding to next turn.");
+            if (GAME_DEBUG_MODE) console.log("[TurnEngine] Game is paused or ended, not proceeding to next turn.");
         }
     }
 
     addTurnPhaseCallback(phase, callback) {
         if (this.turnPhaseCallbacks[phase]) {
             this.turnPhaseCallbacks[phase].push(callback);
-            console.log(`[TurnEngine] Registered callback for '${phase}' phase.`);
+            if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Registered callback for '${phase}' phase.`);
         } else {
-            console.warn(`[TurnEngine] Invalid turn phase: ${phase}`);
+            if (GAME_DEBUG_MODE) console.warn(`[TurnEngine] Invalid turn phase: ${phase}`);
         }
     }
 }

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -40,7 +40,7 @@ export class VFXManager {
     addDamageNumber(unitId, damageAmount, color = 'red') {
         const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
         if (!unit) {
-            console.warn(`[VFXManager] Cannot show damage for unknown unit: ${unitId}`);
+            if (GAME_DEBUG_MODE) console.warn(`[VFXManager] Cannot show damage for unknown unit: ${unitId}`);
             return;
         }
 
@@ -62,13 +62,13 @@ export class VFXManager {
     _onWeaponDropped(data) {
         const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === data.unitId);
         if (!unit) {
-            console.warn(`[VFXManager] Cannot find unit '${data.unitId}' for weapon drop animation.`);
+            if (GAME_DEBUG_MODE) console.warn(`[VFXManager] Cannot find unit '${data.unitId}' for weapon drop animation.`);
             return;
         }
 
         const weaponImage = this.battleSimulationManager.assetLoaderManager.getImage(data.weaponSpriteId);
         if (!weaponImage) {
-            console.warn(`[VFXManager] Weapon sprite '${data.weaponSpriteId}' not loaded.`);
+            if (GAME_DEBUG_MODE) console.warn(`[VFXManager] Weapon sprite '${data.weaponSpriteId}' not loaded.`);
             return;
         }
 
@@ -171,7 +171,7 @@ export class VFXManager {
      */
     drawHpBar(ctx, unit, effectiveTileSize, actualDrawX, actualDrawY) {
         if (!unit || !unit.baseStats) {
-            console.warn("[VFXManager] Cannot draw HP bar: unit data is missing.", unit);
+            if (GAME_DEBUG_MODE) console.warn("[VFXManager] Cannot draw HP bar: unit data is missing.", unit);
             return;
         }
 


### PR DESCRIPTION
## Summary
- add `JudgementManager` to watch AI actions
- create `PositionManager` and rewrite `TargetingManager` and `BasicAIManager`
- emit `AI_ACTION_DECIDED` events and wire up in `TurnEngine`
- register new managers in `GameEngine`
- add new game event constant
- wrap noisy logs behind `GAME_DEBUG_MODE`

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6878ce9e07a88327bafa7dbc1fba252b