### PR TITLE
Fix skill slot passing and add debug logs

### DIFF
--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -39,7 +39,8 @@ export class BattleSimulationManager {
             fullUnitData: fullUnitData,
             currentHp: fullUnitData.currentHp !== undefined ? fullUnitData.currentHp : fullUnitData.baseStats.hp,
             currentBarrier: initialBarrier, // ✨ 현재 배리어 설정
-            maxBarrier: initialBarrier // ✨ 최대 배리어는 초기 배리어와 동일
+            maxBarrier: initialBarrier, // ✨ 최대 배리어는 초기 배리어와 동일
+            skillSlots: fullUnitData.skillSlots || []
         };
         this.unitsOnGrid.push(unitInstance);
         console.log(`[BattleSimulationManager] Added unit '${unitInstance.id}' at (${gridX}, ${gridY}) with initial barrier ${initialBarrier}.`);

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -44,6 +44,7 @@ export class HeroManager {
             const randomName = this.diceBotEngine.pickUniqueItems(this.heroNameList, 1)[0];
 
             const randomSkills = this.diceBotEngine.pickUniqueItems(allWarriorSkillIds, 3);
+            if (GAME_DEBUG_MODE) console.log(`[HeroManager Debug] Warrior ${i+1} (${randomName}) skills:`, randomSkills.join(", "));
 
             const heroUnitData = {
                 id: unitId,


### PR DESCRIPTION
## Summary
- ensure warriors retain their skill slots in `BattleSimulationManager`
- log randomly assigned warrior skills for debugging

## Testing
- `python3 -m http.server 8000 &` *(fail: command not found)*
- `/usr/bin/python3 -m http.server 8000 &`
- `/usr/bin/curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878d110f02c8327aad8cfa969e89df1