### PR TITLE
Add Microcosm hero AI system

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -275,7 +275,18 @@
             // --- 버튼 이벤트 리스너 설정 ---
             document.getElementById('runAllEngineTestsBtn').addEventListener('click', () => {
                 // gameLoop는 gameEngine 내부에 있으므로 gameEngine.gameLoop로 전달 (혹은 getter)
-                runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceEngine, diceBotManager, eventManager);
+                runEngineTests(
+                    renderer,
+                    gameLoop,
+                    battleSimulationManager,
+                    gameEngine.getBattleGridManager(),
+                    idManager,
+                    gameEngine.getAssetLoaderManager(),
+                    diceEngine,
+                    diceBotManager,
+                    eventManager,
+                    gameEngine.getMicrocosmHeroEngine()
+                );
                 runEventManagerTests(eventManager);
                 runGuardianManagerTests(guardianManager);
                 runMeasureManagerIntegrationTest(gameEngine);
@@ -400,8 +411,14 @@
                 runTargetingManagerUnitTests(battleSimulationManager);
             });
 
-            document.getElementById("runHeroEngineUnitTestsBtn").addEventListener("click", () => {
-                runHeroEngineUnitTests(idManager, gameEngine.getAssetLoaderManager(), diceEngine, diceBotManager);
+            document.getElementById("runHeroEngineUnitTestsBtn").addEventListener("click", async () => {
+                await runHeroEngineUnitTests(
+                    idManager,
+                    gameEngine.getAssetLoaderManager(),
+                    diceEngine,
+                    diceBotManager,
+                    gameEngine.getMicrocosmHeroEngine()
+                );
             });
             // ✨ SynergyEngine 단위 테스트 버튼 리스너 추가
             document.getElementById('runSynergyEngineUnitTestsBtn').addEventListener('click', () => {
@@ -598,7 +615,18 @@
             };
 
             // 페이지 로드 시 기본 엔진 테스트 자동 실행
-            runEngineTests(renderer, gameLoop, battleSimulationManager, gameEngine.getBattleGridManager(), idManager, gameEngine.getAssetLoaderManager(), diceEngine, diceBotManager, eventManager);
+            runEngineTests(
+                renderer,
+                gameLoop,
+                battleSimulationManager,
+                gameEngine.getBattleGridManager(),
+                idManager,
+                gameEngine.getAssetLoaderManager(),
+                diceEngine,
+                diceBotManager,
+                eventManager,
+                gameEngine.getMicrocosmHeroEngine()
+            );
             runEventManagerTests(eventManager); // EventManager 테스트도 자동 실행
             runGuardianManagerTests(guardianManager); // GuardianManager 테스트도 자동 실행
             runMeasureManagerIntegrationTest(gameEngine); // MeasureManager 통합 테스트도 자동 실행

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -50,6 +50,7 @@ import { TurnCountManager } from './managers/TurnCountManager.js';
 import { StatusEffectManager } from './managers/StatusEffectManager.js';
 import { WorkflowManager } from './managers/WorkflowManager.js';
 import { HeroEngine } from "./managers/HeroEngine.js"; // HeroEngine 추가
+import { MicrocosmHeroEngine } from './managers/MicrocosmHeroEngine.js'; // ✨ microcosm hero engine
 import { HeroManager } from './managers/HeroManager.js'; // ✨ HeroManager import
 import { SynergyEngine } from './managers/SynergyEngine.js'; // ✨ SynergyEngine 추가
 import { STATUS_EFFECTS } from '../data/statusEffects.js';
@@ -286,12 +287,16 @@ export class GameEngine {
         // ------------------------------------------------------------------
         // 9. Game Content & Feature Engines
         // ------------------------------------------------------------------
+        // ✨ 9-1. Microcosm Hero Engine
+        this.microcosmHeroEngine = new MicrocosmHeroEngine(this.idManager);
+
         // HeroEngine 초기화
         this.heroEngine = new HeroEngine(
             this.idManager,
             this.assetLoaderManager,
             this.diceEngine,
-            this.diceBotEngine
+            this.diceBotEngine,
+            this.microcosmHeroEngine
         );
 
         // ✨ SynergyEngine 초기화
@@ -397,7 +402,7 @@ export class GameEngine {
             this.eventManager,
             this.battleSimulationManager,
             this.turnOrderManager,
-            this.classAIManager,
+            this.microcosmHeroEngine,
             this.delayEngine,
             this.timingEngine,
             this.animationManager,
@@ -761,6 +766,7 @@ export class GameEngine {
     getDiceEngine() { return this.diceEngine; }
     getDiceRollManager() { return this.diceRollManager; }
     getHeroEngine() { return this.heroEngine; }
+    getMicrocosmHeroEngine() { return this.microcosmHeroEngine; }
     // ✨ HeroManager getter 추가
     getHeroManager() { return this.heroManager; }
     // ✨ SynergyEngine getter 추가

--- a/js/managers/HeroEngine.js
+++ b/js/managers/HeroEngine.js
@@ -7,12 +7,13 @@ export class HeroEngine {
      * @param {AssetLoaderManager} assetLoaderManager - 이미지 에셋 로드를 위한 AssetLoaderManager 인스턴스
      * @param {DiceBotEngine} diceBotEngine - 무작위 값 생성을 위한 DiceBotEngine 인스턴스
      */
-    constructor(idManager, assetLoaderManager, diceEngine, diceBotEngine) {
+    constructor(idManager, assetLoaderManager, diceEngine, diceBotEngine, microcosmHeroEngine) {
         console.log("\u2728 HeroEngine initialized. The foundation for all heroes begins here! \u2728");
         this.idManager = idManager;
         this.assetLoaderManager = assetLoaderManager;
         this.diceEngine = diceEngine;
         this.diceBotEngine = diceBotEngine;
+        this.microcosmHeroEngine = microcosmHeroEngine;
 
         this.heroes = new Map(); // key: heroId, value: heroData (생성된 영웅 인스턴스 저장)
         this._loadBasicHeroData(); // 예시 영웅 데이터 로드 (실제는 가챠 등으로 생성)
@@ -130,8 +131,10 @@ export class HeroEngine {
             maxBarrier: 0
         };
 
+        await this.microcosmHeroEngine.createHeroMicrocosm(newHero);
+
         this.heroes.set(heroId, newHero);
-        console.log(`[HeroEngine] Generated new hero: ${newHero.name} (${newHero.id}), Rarity: ${newHero.rarity}, Skills: ${newHero.skills.join(', ')}`);
+        console.log(`[HeroEngine] Generated new hero: ${newHero.name} (${newHero.id})`);
         return newHero;
     }
 

--- a/js/managers/MicrocosmHeroEngine.js
+++ b/js/managers/MicrocosmHeroEngine.js
@@ -1,0 +1,77 @@
+// js/managers/MicrocosmHeroEngine.js
+
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * 각 영웅을 고유한 인스턴스(미시세계)로 관리하고,
+ * 독립적인 AI 로직과 데이터 저장을 총괄하는 엔진입니다.
+ */
+export class MicrocosmHeroEngine {
+    constructor(idManager) {
+        if (GAME_DEBUG_MODE) console.log("\ud83c\udf20 MicrocosmHeroEngine initialized. Every hero is a universe. \ud83c\udf20");
+        this.idManager = idManager; // IndexedDB 및 Cache API 접근
+        this.heroInstances = new Map(); // key: heroId, value: { worker, state, ... }
+    }
+
+    /**
+     * 새로운 영웅의 '미시세계'를 생성하고 초기화합니다.
+     * HeroEngine에서 영웅 생성 시 호출됩니다.
+     * @param {object} heroData - 생성된 영웅의 기본 데이터
+     * @returns {Promise<void>}
+     */
+    async createHeroMicrocosm(heroData) {
+        if (this.heroInstances.has(heroData.id)) {
+            if (GAME_DEBUG_MODE) console.warn(`[MicrocosmHeroEngine] Microcosm for ${heroData.name} already exists.`);
+            return;
+        }
+
+        // 1. Web Worker를 생성하여 영웅의 '뇌(AI)'를 만듭니다.
+        const heroAIWorker = new Worker('./js/workers/heroWorker.js');
+
+        // 2. 영웅의 고유한 상태와 데이터를 IndexedDB에 저장합니다.
+        await this.idManager.addOrUpdateId(heroData.id, heroData);
+
+        const instance = {
+            id: heroData.id,
+            name: heroData.name,
+            worker: heroAIWorker,
+            state: heroData // 이 영웅만의 고유한 상태 정보
+        };
+
+        this.heroInstances.set(heroData.id, instance);
+        if (GAME_DEBUG_MODE) console.log(`[MicrocosmHeroEngine] Created microcosm for ${heroData.name} (${heroData.id}).`);
+    }
+
+    /**
+     * 특정 영웅의 다음 행동을 결정하도록 AI Worker에 요청합니다.
+     * TurnEngine에서 이 메서드를 호출하게 됩니다.
+     * @param {string} heroId - 행동을 결정할 영웅의 ID
+     * @param {object} battleState - 현재 전투 상황 데이터
+     * @returns {Promise<object>} - 영웅이 결정한 행동
+     */
+    determineHeroAction(heroId, battleState) {
+        return new Promise((resolve, reject) => {
+            const instance = this.heroInstances.get(heroId);
+            if (!instance) {
+                return reject(new Error(`No microcosm instance found for hero ${heroId}`));
+            }
+
+            instance.worker.postMessage({
+                type: 'DETERMINE_ACTION',
+                heroState: instance.state,
+                battleState: battleState
+            });
+
+            instance.worker.onmessage = (event) => {
+                if (event.data.type === 'ACTION_DECIDED') {
+                    if (GAME_DEBUG_MODE) console.log(`[MicrocosmHeroEngine] ${instance.name} decided to:`, event.data.action);
+                    resolve(event.data.action);
+                }
+            };
+
+            instance.worker.onerror = (err) => {
+                reject(err);
+            };
+        });
+    }
+}

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -4,12 +4,12 @@
 import { GAME_EVENTS, UI_STATES, ATTACK_TYPES, GAME_DEBUG_MODE } from '../constants.js';
 
 export class TurnEngine {
-    constructor(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager, statusEffectManager) {
+    constructor(eventManager, battleSimulationManager, turnOrderManager, microcosmHeroEngine, delayEngine, timingEngine, animationManager, battleCalculationManager, statusEffectManager) {
         if (GAME_DEBUG_MODE) console.log("\uD83D\uDD01 TurnEngine initialized. Ready to manage game turns. \uD83D\uDD01");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
         this.turnOrderManager = turnOrderManager;
-        this.classAIManager = classAIManager;
+        this.microcosmHeroEngine = microcosmHeroEngine;
         this.delayEngine = delayEngine;
         this.timingEngine = timingEngine;
         this.animationManager = animationManager;
@@ -107,7 +107,11 @@ export class TurnEngine {
             if (!canUnitAct) {
                 await this.delayEngine.waitFor(500);
             } else {
-                action = await this.classAIManager.getBasicClassAction(unit, this.battleSimulationManager.unitsOnGrid);
+                const battleState = {
+                    enemies: this.battleSimulationManager.unitsOnGrid.filter(u => u.type !== unit.type),
+                    allies: this.battleSimulationManager.unitsOnGrid.filter(u => u.type === unit.type)
+                };
+                action = await this.microcosmHeroEngine.determineHeroAction(unit.id, battleState);
             }
 
             // JudgementManager가 AI 결정을 감시할 수 있도록 알림

--- a/js/workers/heroWorker.js
+++ b/js/workers/heroWorker.js
@@ -1,0 +1,51 @@
+// js/workers/heroWorker.js
+
+/**
+ * 개별 영웅의 AI 로직을 처리하는 워커입니다.
+ * 이 워커는 자신만의 '작은 엔진'을 가집니다.
+ */
+
+// 이 워커의 '작은 엔진': 스킬 사용 결정 로직
+function decideSkillToUse(heroState) {
+    const skillRoll = Math.random();
+    if (skillRoll < 0.4 && heroState.skillSlots[0]) {
+        return heroState.skillSlots[0];
+    } else if (skillRoll < 0.7 && heroState.skillSlots[1]) {
+        return heroState.skillSlots[1];
+    } else if (skillRoll < 0.9 && heroState.skillSlots[2]) {
+        return heroState.skillSlots[2];
+    }
+    return null;
+}
+
+self.onmessage = (event) => {
+    const { type, heroState, battleState } = event.data;
+
+    if (type === 'DETERMINE_ACTION') {
+        let action = null;
+
+        const skillToUse = decideSkillToUse(heroState);
+
+        if (skillToUse) {
+            const targetId = battleState.enemies[0]?.id;
+            action = {
+                actionType: 'skill',
+                skillId: skillToUse,
+                targetId: targetId,
+                logMessage: `${heroState.name}\uAC00 \uC790\uC2E0\uC758 \uC2A4\uD0AC '${skillToUse}'(\uC744) \uC0AC\uC6A9\uD588\uB2E4!`
+            };
+        } else {
+            const targetId = battleState.enemies[0]?.id;
+            action = {
+                actionType: 'attack',
+                targetId: targetId,
+                logMessage: `${heroState.name}\uAC00 ${targetId}\uC5D0\uAC8C \uC77C\uBC18 \uACF5\uACA9\uC744 \uAC00\uD588\uB2E4!`
+            };
+        }
+
+        self.postMessage({
+            type: 'ACTION_DECIDED',
+            action: action
+        });
+    }
+};

--- a/tests/index.js
+++ b/tests/index.js
@@ -72,7 +72,8 @@ export function runEngineTests(
     assetLoaderManager = null,
     diceEngine = null,
     diceBotEngine = null,
-    eventManager = null
+    eventManager = null,
+    microcosmHeroEngine = null
 ) {
     runRendererTests(renderer);
     runGameLoopTests(gameLoop);
@@ -82,7 +83,7 @@ export function runEngineTests(
     if (battleSimulationManager) {
         runTargetingManagerUnitTests(battleSimulationManager);
     }
-    runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine, diceBotEngine);
+    runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine, diceBotEngine, microcosmHeroEngine);
     if (idManager && eventManager) {
         runSynergyEngineUnitTests(idManager, eventManager);
     }

--- a/tests/unit/heroEngineUnitTests.js
+++ b/tests/unit/heroEngineUnitTests.js
@@ -2,7 +2,7 @@
 
 import { HeroEngine } from '../../js/managers/HeroEngine.js';
 
-export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine, diceBotManager) {
+export async function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine, diceBotManager, microcosmHeroEngine) {
     console.log("--- HeroEngine Unit Test Start ---");
 
     let testCount = 0;
@@ -40,10 +40,15 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine
         getRandomFloat: () => Math.random()
     };
 
+    const mockMicrocosmHeroEngine = microcosmHeroEngine || {
+        async createHeroMicrocosm() {},
+        async determineHeroAction() { return null; }
+    };
+
     // 테스트 1: 초기화 확인
     testCount++;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine, mockMicrocosmHeroEngine);
         if (heroEngine.idManager === mockIdManager && heroEngine.heroes instanceof Map) {
             console.log("HeroEngine: Initialized correctly. [PASS]");
             passCount++;
@@ -59,7 +64,7 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine
     mockDiceBotEngine.getRandomIntResults = [100, 50, 20, 10, 15, 5, 10, 20, 30, 60, 1, 4, 1];
     mockDiceBotEngine.getRandomIntIndex = 0;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine, mockMicrocosmHeroEngine);
         const hero = await heroEngine.generateHero({
             name: '테스트 영웅',
             classId: 'class_test',
@@ -81,7 +86,7 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine
     // 테스트 3: getHero - 존재하는 영웅 가져오기
     testCount++;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine, mockMicrocosmHeroEngine);
         const generatedHero = await heroEngine.generateHero({ heroId: 'test_hero_get', name: '가져올 영웅' });
         heroEngine.heroes.set(generatedHero.id, generatedHero);
 
@@ -99,7 +104,7 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine
     // 테스트 4: getHero - 존재하지 않는 영웅 가져오기
     testCount++;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine, mockMicrocosmHeroEngine);
         const nonExistentHero = heroEngine.getHero('non_existent_hero');
         if (nonExistentHero === undefined) {
             console.log("HeroEngine: getHero returned undefined for non-existent hero. [PASS]");
@@ -114,7 +119,7 @@ export function runHeroEngineUnitTests(idManager, assetLoaderManager, diceEngine
     // 테스트 5: getAllHeroes - 모든 영웅 목록 반환
     testCount++;
     try {
-        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine);
+        const heroEngine = new HeroEngine(mockIdManager, mockAssetLoaderManager, diceEngine, mockDiceBotEngine, mockMicrocosmHeroEngine);
         await heroEngine.generateHero({ heroId: 'hero_1', name: 'Hero One' });
         await heroEngine.generateHero({ heroId: 'hero_2', name: 'Hero Two' });
         const allHeroes = heroEngine.getAllHeroes();


### PR DESCRIPTION
## Summary
- create **MicrocosmHeroEngine** to host hero-specific AI instances
- add hero AI worker
- integrate new engine with `GameEngine`, `HeroEngine`, and `TurnEngine`
- update hero engine tests for new microcosm dependency
- wire up unit test helpers in `debug.html`

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6878d2a3c840832780e23e971338b70c