### PR TITLE
Reduce debug noise

### DIFF
--- a/js/managers/BattleGridManager.js
+++ b/js/managers/BattleGridManager.js
@@ -41,7 +41,7 @@ export class BattleGridManager {
         const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
         if (GAME_DEBUG_MODE) {
-            console.log(`[BattleGridManager Debug] Drawing Grid Parameters (in draw()): \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\nScene Content (Logical): ${sceneContentDimensions.width}x${sceneContentDimensions.height}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}\n            Total Grid Render Size (Logical): ${totalGridWidth.toFixed(2)}x${totalGridHeight.toFixed(2)}`);
+            // console.log(`[BattleGridManager Debug] Drawing Grid Parameters (in draw()): \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\nScene Content (Logical): ${sceneContentDimensions.width}x${sceneContentDimensions.height}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}\n            Total Grid Render Size (Logical): ${totalGridWidth.toFixed(2)}x${totalGridHeight.toFixed(2)}`);
         }
 
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)';
@@ -50,7 +50,7 @@ export class BattleGridManager {
         // 세로선 그리기
         for (let i = 0; i <= this.gridCols; i++) {
             const lineX = gridOffsetX + i * effectiveTileSize;
-            if (GAME_DEBUG_MODE) console.log(`[BattleGridManager Debug] Vertical Line ${i}: X=${lineX.toFixed(2)} from Y=${gridOffsetY.toFixed(2)} to Y=${(gridOffsetY + totalGridHeight).toFixed(2)}`);
+            // if (GAME_DEBUG_MODE) console.log(`[BattleGridManager Debug] Vertical Line ${i}: X=${lineX.toFixed(2)} from Y=${gridOffsetY.toFixed(2)} to Y=${(gridOffsetY + totalGridHeight).toFixed(2)}`);
             ctx.beginPath();
             ctx.moveTo(lineX, gridOffsetY);
             ctx.lineTo(lineX, gridOffsetY + totalGridHeight);
@@ -60,7 +60,7 @@ export class BattleGridManager {
         // 가로선 그리기
         for (let i = 0; i <= this.gridRows; i++) {
             const lineY = gridOffsetY + i * effectiveTileSize;
-            if (GAME_DEBUG_MODE) console.log(`[BattleGridManager Debug] Horizontal Line ${i}: Y=${lineY.toFixed(2)} from X=${gridOffsetX.toFixed(2)} to X=${(gridOffsetX + totalGridWidth).toFixed(2)}`);
+            // if (GAME_DEBUG_MODE) console.log(`[BattleGridManager Debug] Horizontal Line ${i}: Y=${lineY.toFixed(2)} from X=${gridOffsetX.toFixed(2)} to X=${(gridOffsetX + totalGridWidth).toFixed(2)}`);
             ctx.beginPath();
             ctx.moveTo(gridOffsetX, lineY);
             ctx.lineTo(gridOffsetX + totalGridWidth, lineY);
@@ -68,7 +68,7 @@ export class BattleGridManager {
         }
 
         // 그리드 영역 테두리 (확인용)
-        if (GAME_DEBUG_MODE) console.log(`[BattleGridManager Debug] Border Rect: X=${gridOffsetX.toFixed(2)}, Y=${gridOffsetY.toFixed(2)}, W=${totalGridWidth.toFixed(2)}, H=${totalGridHeight.toFixed(2)}`);
+        // if (GAME_DEBUG_MODE) console.log(`[BattleGridManager Debug] Border Rect: X=${gridOffsetX.toFixed(2)}, Y=${gridOffsetY.toFixed(2)}, W=${totalGridWidth.toFixed(2)}, H=${totalGridHeight.toFixed(2)}`);
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
         ctx.lineWidth = 2;
         ctx.strokeRect(gridOffsetX, gridOffsetY, totalGridWidth, totalGridHeight);

--- a/js/managers/BindingManager.js
+++ b/js/managers/BindingManager.js
@@ -13,10 +13,10 @@ export class BindingManager {
      */
     bindUnit(unitId, components) {
         if (this.unitBindings.has(unitId)) {
-            console.warn(`[BindingManager] Unit '${unitId}' already has existing bindings. Overwriting.`);
+            // console.warn(`[BindingManager] Unit '${unitId}' already has existing bindings. Overwriting.`);
         }
         this.unitBindings.set(unitId, components);
-        console.log(`[BindingManager] Bound components to unit '${unitId}'.`);
+        // console.log(`[BindingManager] Bound components to unit '${unitId}'.`);
     }
 
     /**

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -255,7 +255,7 @@ export class VFXManager {
         const gridOffsetY = (canvasHeight - totalGridHeight) / 2;
 
         // ✨ DEBUG LOG START FOR VFXManager Drawing Parameters
-        if (GAME_DEBUG_MODE) console.log(`[VFXManager Debug] Drawing VFX Parameters: \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}`);
+        // if (GAME_DEBUG_MODE) console.log(`[VFXManager Debug] Drawing VFX Parameters: \n            Canvas (Logical): ${canvasWidth}x${canvasHeight}\n            Effective Tile Size: ${effectiveTileSize.toFixed(2)}\n            Grid Offset (X, Y): ${gridOffsetX.toFixed(2)}, ${gridOffsetY.toFixed(2)}`);
         // ✨ DEBUG LOG END FOR VFXManager Drawing Parameters
 
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
@@ -269,7 +269,7 @@ export class VFXManager {
                 gridOffsetY
             );
             // ✨ 추가: 각 유닛의 HP/배리어 바가 그려지는 최종 위치 로그
-            if (GAME_DEBUG_MODE) console.log(`[VFXManager Debug] Unit ${unit.id} (HP/Barrier Bar): drawX=${drawX.toFixed(2)}, drawY=${drawY.toFixed(2)}`);
+            // if (GAME_DEBUG_MODE) console.log(`[VFXManager Debug] Unit ${unit.id} (HP/Barrier Bar): drawX=${drawX.toFixed(2)}, drawY=${drawY.toFixed(2)}`);
             this.drawHpBar(ctx, unit, effectiveTileSize, drawX, drawY);
             this.drawBarrierBar(ctx, unit, effectiveTileSize, drawX, drawY); // ✨ 배리어 바 그리기 호출
         }


### PR DESCRIPTION
## Summary
- silence excessive console logs in `BattleGridManager`, `VFXManager` and `BindingManager`
- keep conditions for further debugging but hide logs by default

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878d6c83fcc8327843dc87ce1c7149d