### PR TITLE
Add hero recruitment and birth reporting

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,8 @@
     </div>
     <button id="toggleHeroPanelBtn" style="position: absolute; top: 10px; right: 10px; z-index: 100;">영웅 패널</button>
     <!-- ✨ 캔버스 버튼 외에 별도의 HTML 전투 시작 버튼 -->
-    <button id="battleStartHtmlBtn" class="game-button">전투 시작</button>
+    <button id="recruitWarriorBtn" class="game-button" style="bottom: 10px; left: calc(50% - 150px);">전사 고용</button>
+    <button id="battleStartHtmlBtn" class="game-button" style="bottom: 10px; left: calc(50% + 10px);">전투 시작</button>
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,6 @@
 // js/main.js
 import { GameEngine } from './GameEngine.js';
 // ✨ 상수 파일 임포트
-import { BUTTON_IDS } from './constants.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     try {
@@ -9,23 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
         gameEngine.eventManager.setGameRunningState(true); // ✨ 게임 시작 시 상태 설정
         gameEngine.start();
 
-        // 영웅 패널 버튼 클릭 이벤트 리스너 추가
-        const toggleHeroPanelBtn = document.getElementById(BUTTON_IDS.TOGGLE_HERO_PANEL); // ✨ 상수 사용
-        if (toggleHeroPanelBtn) {
-            toggleHeroPanelBtn.addEventListener('click', () => {
-                gameEngine.getUIEngine().toggleHeroPanel();
-            });
-        } else {
-            console.warn("Hero Panel toggle button not found in main.js.");
-        }
-
-        // ✨ 별도의 HTML 전투 시작 버튼 리스너
-        const battleStartHtmlBtn = document.getElementById(BUTTON_IDS.BATTLE_START_HTML);
-        if (battleStartHtmlBtn) {
-            battleStartHtmlBtn.addEventListener('click', () => {
-                gameEngine.getUIEngine().handleBattleStartClick();
-            });
-        }
+        // 버튼 리스너는 GameEngine에서 처리합니다.
     } catch (error) {
         console.error("Fatal Error: Game Engine failed to start.", error);
         alert("\uAC8C\uC784 \uC2DC\uC791 \uC911 \uCE58\uBA85\uC801\uC778 \uC624\uB958\uAC00 \uBC1C\uC0DD\uD588\uC2B5\uB2C8\uB2E4. \uCF58\uC194\uC744 \uD655\uC778\uD574\uC8FC\uC138\uC694.");

--- a/js/managers/BattleFormationManager.js
+++ b/js/managers/BattleFormationManager.js
@@ -14,17 +14,22 @@ export class BattleFormationManager {
         const formationPositions = [
             { x: 2, y: 3 }, { x: 2, y: 5 }, { x: 4, y: 4 },
             { x: 4, y: 2 }, { x: 4, y: 6 }, { x: 0, y: 4 }
+            // 필요하다면 더 많은 포지션 추가
         ];
 
-        allyUnits.forEach((unit, index) => {
-            if (index < formationPositions.length) {
-                const pos = formationPositions[index];
+        for (const unit of allyUnits) {
+            const placedAlliesCount = this.battleSimulationManager.unitsOnGrid.filter(u => u.type === 'mercenary').length;
+
+            if (placedAlliesCount < formationPositions.length) {
+                const pos = formationPositions[placedAlliesCount];
                 unit.gridX = pos.x;
                 unit.gridY = pos.y;
                 const unitImage = this.battleSimulationManager.assetLoaderManager.getImage(unit.spriteId);
                 this.battleSimulationManager.addUnit(unit, unitImage, pos.x, pos.y);
                 console.log(`[BattleFormationManager] Placed ${unit.name} at (${pos.x}, ${pos.y})`);
+            } else {
+                console.warn(`[BattleFormationManager] No available slots to place ${unit.name}.`);
             }
-        });
+        }
     }
 }

--- a/js/managers/BirthReportManager.js
+++ b/js/managers/BirthReportManager.js
@@ -1,0 +1,50 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * 새로운 영웅의 탄생 정보를 콘솔에 상세히 보고하는 매니저입니다.
+ * 영웅의 모든 스탯, 스킬, 그리고 그를 구성하는 로직을 투명하게 보여줍니다.
+ */
+export class BirthReportManager {
+    constructor() {
+        if (GAME_DEBUG_MODE) console.log("\ud83d\udcda BirthReportManager initialized. Ready to document new heroes.");
+    }
+
+    /**
+     * 새로운 영웅의 출생 신고를 콘솔에 출력합니다.
+     * @param {object} heroData - 생성된 영웅의 전체 데이터
+     */
+    report(heroData) {
+        if (!heroData) return;
+
+        console.group(`%c\ud83d\udcdc \uCD9C\uC0DD \uC2E0\uACE0: ${heroData.name} (ID: ${heroData.id})`, "color: #4CAF50; font-size: 1.2em; font-weight: bold;");
+
+        console.log("\uc774 \uc601\uc6b4\uc740 [\ubbf8\uc2dc\uc138\uacc4 \uc601\uc6b4 \uc5d4\uc9c4]\uc5d0 \uc758\ud574 \ub3d9\ub9f9\ub41c \uac1d\uccb4\ub85c \uc0dd\uc131\ub418\uc5c8\uc2b5\ub2c8\ub2e4.");
+        console.log("\uace0\uc720\ud55c AI Worker\uc640 \uc601\uad6c\uc801\uc778 \ub370\uc774\ud130 \uc800\uc7a5\uc18c\ub97c \uac00\uc9c0\uace0 \uc788\uc2b5\ub2c8\ub2e4.");
+
+        console.group("\uae30\ubcf8 \uc815\ubcf4");
+        console.log(`\ud074\ub798\uc2a4: ${heroData.classId}`);
+        console.log(`\ud76c\uadc0\ub3c4: ${heroData.rarity || 'common'}`);
+        console.groupEnd();
+
+        console.group("\uae30\ubcf8 \uc2a4\ud0dc\ud2b8 (Base Stats)");
+        console.table(heroData.baseStats);
+        console.groupEnd();
+
+        console.group("\uc2a4\ud0ac \uc2ac\ub86f (Skill Slots)");
+        if (heroData.skillSlots && heroData.skillSlots.length > 0) {
+            heroData.skillSlots.forEach((skillId, index) => {
+                console.log(`\uc2ac\ub86f ${index + 1}: ${skillId}`);
+            });
+        } else {
+            console.log("\ud560\ub2dd\ub41c \uc2a4\ud0ac \uc5c6\uc74c");
+        }
+        console.groupEnd();
+
+        console.group("\uace0\uc720 \ud2b9\uc131 (Traits) \ubc0f \uc2dc\ub0b4\uc9c0 (Synergies)");
+        console.log("\ud2b9\uc131:", heroData.traits?.join(', ') || "\uc5c6\uc74c");
+        console.log("\uc2dc\ub0b4\uc9c0:", heroData.synergies?.join(', ') || "\uc5c6\uc74c");
+        console.groupEnd();
+
+        console.groupEnd();
+    }
+}

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -6,7 +6,7 @@ import { CLASSES } from '../../data/class.js';
 import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 
 export class HeroManager {
-    constructor(idManager, diceEngine, assetLoaderManager, battleSimulationManager, unitSpriteEngine, diceBotEngine) {
+    constructor(idManager, diceEngine, assetLoaderManager, battleSimulationManager, unitSpriteEngine, diceBotEngine, birthReportManager) {
         if (GAME_DEBUG_MODE) console.log("\u2728 HeroManager initialized. Ready to create legendary heroes. \u2728");
         this.idManager = idManager;
         this.diceEngine = diceEngine;
@@ -14,6 +14,7 @@ export class HeroManager {
         this.battleSimulationManager = battleSimulationManager;
         this.unitSpriteEngine = unitSpriteEngine;
         this.diceBotEngine = diceBotEngine;
+        this.birthReportManager = birthReportManager;
         this.heroNameList = [
             '레오닉', '아서스', '가로쉬', '스랄', '제이나', '안두인',
             '바리안', '실바나스', '그롬마쉬', '렉사르', '알렉스트라자', '이렐리아'
@@ -68,6 +69,10 @@ export class HeroManager {
                 finish: 'assets/images/warrior-finish.png',
                 status: 'assets/images/warrior-status-effects.png'
             });
+
+            if (this.birthReportManager) {
+                this.birthReportManager.report(heroUnitData);
+            }
 
             createdHeroes.push(heroUnitData);
             if (GAME_DEBUG_MODE) console.log(`[HeroManager] Created data for warrior: ${heroUnitData.name}`);


### PR DESCRIPTION
## Summary
- integrate BirthReportManager to log hero creation
- update GameEngine to use BirthReportManager and hook DOM buttons
- remove automatic hero spawn and add recruit button logic
- adjust formation placement logic for new recruits
- streamline main entry script and add recruit button to HTML

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878dd65f7a88327a18c98a535d4ef06