### PR TITLE
Fix microcosm fallback in AI processing

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -404,6 +404,7 @@ export class GameEngine {
             this.battleSimulationManager,
             this.turnOrderManager,
             this.microcosmHeroEngine,
+            this.classAIManager,
             this.delayEngine,
             this.timingEngine,
             this.animationManager,

--- a/js/managers/MicrocosmHeroEngine.js
+++ b/js/managers/MicrocosmHeroEngine.js
@@ -13,6 +13,10 @@ export class MicrocosmHeroEngine {
         this.heroInstances = new Map(); // key: heroId, value: { worker, state, ... }
     }
 
+    hasHeroMicrocosm(heroId) {
+        return this.heroInstances.has(heroId);
+    }
+
     /**
      * 새로운 영웅의 '미시세계'를 생성하고 초기화합니다.
      * HeroEngine에서 영웅 생성 시 호출됩니다.
@@ -53,7 +57,9 @@ export class MicrocosmHeroEngine {
         return new Promise((resolve, reject) => {
             const instance = this.heroInstances.get(heroId);
             if (!instance) {
-                return reject(new Error(`No microcosm instance found for hero ${heroId}`));
+                if (GAME_DEBUG_MODE) console.warn(`[MicrocosmHeroEngine] No microcosm instance for hero ${heroId}.`);
+                resolve(null);
+                return;
             }
 
             instance.worker.postMessage({


### PR DESCRIPTION
## Summary
- add `hasHeroMicrocosm` method to `MicrocosmHeroEngine`
- resolve `determineHeroAction` with `null` if no microcosm exists
- inject `classAIManager` into `TurnEngine` and fall back to class-based AI when microcosm is missing
- update `GameEngine` to pass `classAIManager` to `TurnEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878dfa159588327b3fa37c3431a33f0