### PR TITLE
Fix DataCloneError when storing hero data

### DIFF
--- a/js/managers/HeroEngine.js
+++ b/js/managers/HeroEngine.js
@@ -68,8 +68,9 @@ export class HeroEngine {
         const classId = options.classId || 'class_warrior'; // 기본 전사 클래스
 
         // 1. 일러스트 로드 (AssetLoaderManager 활용)
-        const illustrationImage = options.spriteId ?
-            this.assetLoaderManager.getImage(options.spriteId) || await this.assetLoaderManager.loadImage(options.spriteId, `assets/images/${options.spriteId.replace('hero_default_', '')}.png`) :
+        const spriteId = options.spriteId || null;
+        const illustrationImage = spriteId ?
+            this.assetLoaderManager.getImage(spriteId) || await this.assetLoaderManager.loadImage(spriteId, `assets/images/${spriteId.replace('hero_default_', '')}.png`) :
             null;
 
         // 2. 랜덤 스탯 생성 (DiceBotEngine 활용)
@@ -118,6 +119,7 @@ export class HeroEngine {
             id: heroId,
             name: heroName,
             classId: classId,
+            spriteId: spriteId,
             rarity: options.rarity || 'common',
             illustration: illustrationImage,
             baseStats: baseStats,

--- a/js/managers/MicrocosmHeroEngine.js
+++ b/js/managers/MicrocosmHeroEngine.js
@@ -33,7 +33,8 @@ export class MicrocosmHeroEngine {
         const heroAIWorker = new Worker('./js/workers/heroWorker.js');
 
         // 2. 영웅의 고유한 상태와 데이터를 IndexedDB에 저장합니다.
-        await this.idManager.addOrUpdateId(heroData.id, heroData);
+        const { illustration, ...serializableData } = heroData;
+        await this.idManager.addOrUpdateId(heroData.id, serializableData);
 
         const instance = {
             id: heroData.id,


### PR DESCRIPTION
## Summary
- include `spriteId` when generating heroes
- strip the `illustration` image before storing hero data in IndexedDB

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878e10790c08327a1aac1ef7538932b