### PR TITLE
Fix skill reference and AI init order

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -386,6 +386,26 @@ export class GameEngine {
             this.battleSimulationManager,
             this.weightEngine // ✨ weightEngine 추가
         );
+
+        // ✨ WarriorSkillsAI를 먼저 생성하여 ClassAIManager에 주입
+        const commonManagersForSkills = {
+            battleSimulationManager: this.battleSimulationManager,
+            battleCalculationManager: this.battleCalculationManager,
+            eventManager: this.eventManager,
+            delayEngine: this.delayEngine,
+            statusEffectManager: this.statusEffectManager,
+            coordinateManager: this.coordinateManager,
+            targetingManager: this.targetingManager,
+            vfxManager: this.vfxManager,
+            diceEngine: this.diceEngine,
+            workflowManager: this.workflowManager,
+            animationManager: this.animationManager,
+            measureManager: this.measureManager,
+            idManager: this.idManager,
+            movingManager: this.movingManager
+        };
+        this.warriorSkillsAI = new WarriorSkillsAI(commonManagersForSkills);
+
         // ClassAIManager에 추가 매니저 전달
         this.classAIManager = new ClassAIManager(
             this.idManager,
@@ -411,25 +431,6 @@ export class GameEngine {
             this.battleCalculationManager,
             this.statusEffectManager
         );
-
-        // ✨ 워리어 스킬 AI 초기화 (다른 매니저들을 주입)
-        const commonManagersForSkills = {
-            battleSimulationManager: this.battleSimulationManager,
-            battleCalculationManager: this.battleCalculationManager,
-            eventManager: this.eventManager,
-            delayEngine: this.delayEngine,
-            statusEffectManager: this.statusEffectManager,
-            coordinateManager: this.coordinateManager,
-            targetingManager: this.targetingManager,
-            vfxManager: this.vfxManager,
-            diceEngine: this.diceEngine,
-            workflowManager: this.workflowManager,
-            animationManager: this.animationManager,
-            measureManager: this.measureManager,
-            idManager: this.idManager,
-            movingManager: this.movingManager
-        };
-        this.warriorSkillsAI = new WarriorSkillsAI(commonManagersForSkills);
 
         // ------------------------------------------------------------------
         // 12. Sprite & Action Managers
@@ -494,17 +495,20 @@ export class GameEngine {
         this.sceneEngine.setCurrentScene(UI_STATES.MAP_SCREEN);
 
         this.layerEngine.registerLayer('sceneLayer', (ctx) => {
+            this.renderer.ctx.save();
+            this.cameraEngine.applyTransform(this.renderer.ctx); // 카메라 변환 적용
             this.sceneEngine.draw(ctx);
+
+            // ✨ 같은 변환을 사용하는 레이어들을 여기에 추가
+            this.statusIconManager.draw(ctx);
+            this.passiveIconManager.draw(ctx);
+
+            this.renderer.ctx.restore();
         }, 10);
 
-        // ✨ StatusIconManager의 draw 메서드를 레이어로 등록 (VFXManager 위에 표시)
-        this.layerEngine.registerLayer('statusIconLayer', (ctx) => {
-            this.statusIconManager.draw(ctx);
-        }, 15);
-
-        this.layerEngine.registerLayer('passiveIconLayer', (ctx) => {
-            this.passiveIconManager.draw(ctx);
-        }, 16); // 상태이상 아이콘 위에 그려지도록 z-index 조정
+        // 개별 레이어 등록 제거
+        // this.layerEngine.registerLayer('statusIconLayer', ...);
+        // this.layerEngine.registerLayer('passiveIconLayer', ...);
 
         this.layerEngine.registerLayer('uiLayer', (ctx) => {
             this.uiEngine.draw(ctx);

--- a/js/managers/BasicAIManager.js
+++ b/js/managers/BasicAIManager.js
@@ -64,9 +64,15 @@ export class BasicAIManager {
         const pathToTarget = this.positionManager.findPath({ x: unit.gridX, y: unit.gridY }, { x: target.gridX, y: target.gridY }, moveRange);
         if (pathToTarget && pathToTarget.length > 1) {
             // 경로의 마지막 지점은 적이므로, 그 바로 앞 칸으로 이동
-            const moveDestination = pathToTarget[Math.min(pathToTarget.length - 2, moveRange)];
-            if (GAME_DEBUG_MODE) console.log(`[BasicAIManager] ${unit.name} cannot reach attack position. Moving closer to ${target.name} at (${moveDestination.x},${moveDestination.y}).`);
-            return { actionType: 'move', moveTargetX: moveDestination.x, moveTargetY: moveDestination.y };
+            // ✨ 경로가 이동 범위보다 길 경우, 이동 가능한 최대 지점으로 이동하도록 수정
+            const moveIndex = Math.min(pathToTarget.length - 1, moveRange);
+            const moveDestination = pathToTarget[moveIndex];
+
+            // ✨ 목적지가 비어있는지 마지막으로 확인
+            if (moveDestination && !this.positionManager.battleSimulationManager.isTileOccupied(moveDestination.x, moveDestination.y, unit.id)) {
+                if (GAME_DEBUG_MODE) console.log(`[BasicAIManager] ${unit.name} cannot reach attack position. Moving closer to ${target.name} at (${moveDestination.x},${moveDestination.y}).`);
+                return { actionType: 'move', moveTargetX: moveDestination.x, moveTargetY: moveDestination.y };
+            }
         }
 
         if (GAME_DEBUG_MODE) console.log(`[BasicAIManager] ${unit.name} has no possible action.`);

--- a/js/managers/DetailInfoManager.js
+++ b/js/managers/DetailInfoManager.js
@@ -237,10 +237,11 @@ export class DetailInfoManager {
         ctx.fillText(`지혜: ${baseStats.wisdom || 0} | 운: ${baseStats.luck || 0}`, tooltipX + padding, tooltipY + currentYOffset);
         currentYOffset += lineHeight + 5;
 
-        // 스킬 정보 (HeroEngine에서 가져온 heroDetails에 스킬이 있다면)
+        // 스킬 정보 (HeroEngine에서 가져온 heroDetails에 스킬이 있다면 우선 사용)
         let skillsToList = [];
-        if (heroDetails && heroDetails.skills && heroDetails.skills.length > 0) {
-            skillsToList = heroDetails.skills;
+        // ✨ 수정된 부분: heroDetails.skillSlots을 먼저 확인하도록 변경
+        if (heroDetails && heroDetails.skillSlots && heroDetails.skillSlots.length > 0) {
+            skillsToList = heroDetails.skillSlots;
         } else if (classData && classData.skills && classData.skills.length > 0) {
             skillsToList = classData.skills;
         }

--- a/js/managers/PassiveIconManager.js
+++ b/js/managers/PassiveIconManager.js
@@ -19,8 +19,8 @@ export class PassiveIconManager {
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
             if (unit.currentHp <= 0) continue;
 
-            const classData = await this.idManager.get(unit.classId);
-            if (classData && classData.skills && classData.skills.includes(WARRIOR_SKILLS.IRON_WILL.id)) {
+            // ✨ 수정된 부분: classData를 조회하는 대신 unit의 skillSlots을 직접 확인
+            if (unit.skillSlots && unit.skillSlots.includes(WARRIOR_SKILLS.IRON_WILL.id)) {
                 const icon = this.skillIconManager.getSkillIcon(WARRIOR_SKILLS.IRON_WILL.id);
                 if (icon) {
                     const { drawX, drawY } = this.battleSimulationManager.animationManager.getRenderPosition(


### PR DESCRIPTION
## Summary
- prioritize hero skillSlots when showing unit detail info
- check unit.skillSlots directly when drawing passive icons
- avoid invalid AI initialisation by creating WarriorSkillsAI before ClassAIManager
- consolidate scene layer rendering with camera transform for icons
- improve BasicAIManager move logic to check path length

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878e3989068832795874a91ea40edfd