### PR TITLE
Fix AI pathfinding so units move toward far targets

### DIFF
--- a/js/managers/BasicAIManager.js
+++ b/js/managers/BasicAIManager.js
@@ -61,7 +61,10 @@ export class BasicAIManager {
         }
 
         // 공격 위치로 이동할 수 없을 때: 그냥 적에게 다가간다.
-        const pathToTarget = this.positionManager.findPath({ x: unit.gridX, y: unit.gridY }, { x: target.gridX, y: target.gridY }, moveRange);
+        const pathToTarget = this.positionManager.findPath(
+            { x: unit.gridX, y: unit.gridY },
+            { x: target.gridX, y: target.gridY }
+        );
         if (pathToTarget && pathToTarget.length > 1) {
             // 경로의 마지막 지점은 적이므로, 그 바로 앞 칸으로 이동
             // ✨ 경로가 이동 범위보다 길 경우, 이동 가능한 최대 지점으로 이동하도록 수정

--- a/js/managers/PositionManager.js
+++ b/js/managers/PositionManager.js
@@ -45,15 +45,16 @@ export class PositionManager {
      * @param {number} maxMoveRange - 최대 이동 가능 거리
      * @returns {Array<{x: number, y: number}> | null} 경로 배열 또는 null
      */
-    findPath(startPos, endPos, maxMoveRange) {
-        const queue = [{ x: startPos.x, y: startPos.y, path: [{x: startPos.x, y: startPos.y}], dist: 0 }];
+    findPath(startPos, endPos, maxMoveRange = Infinity) {
+        const maxRange = (maxMoveRange === undefined || maxMoveRange === null) ? Infinity : maxMoveRange;
+        const queue = [{ x: startPos.x, y: startPos.y, path: [{ x: startPos.x, y: startPos.y }], dist: 0 }];
         const visited = new Set([`${startPos.x},${startPos.y}`]);
         const directions = [[0, 1], [0, -1], [1, 0], [-1, 0]]; // 4방향 이동
 
         while (queue.length > 0) {
             const current = queue.shift();
 
-            if (current.dist >= maxMoveRange) continue;
+            if (current.dist >= maxRange) continue;
 
             for (const [dx, dy] of directions) {
                 const nextX = current.x + dx;


### PR DESCRIPTION
## Summary
- let PositionManager's `findPath` search unlimited distance by default
- have BasicAIManager use the unlimited path when moving toward distant foes

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878e5ba4b1c832784f56e8e5269dec8