### PR TITLE
Fix TargetingManager reduce error

### DIFF
--- a/js/managers/TargetingManager.js
+++ b/js/managers/TargetingManager.js
@@ -44,7 +44,19 @@ export class TargetingManager {
      * @returns {object | null}
      */
     getLowestHpUnit(unitList) {
-        return unitList.reduce((lowest, unit) => {
+        let list = unitList;
+
+        // Allow passing a unit type string for convenience
+        if (typeof unitList === 'string') {
+            list = this.battleSimulationManager.unitsOnGrid
+                .filter(u => u.type === unitList && u.currentHp > 0);
+        }
+
+        if (!Array.isArray(list) || list.length === 0) {
+            return null;
+        }
+
+        return list.reduce((lowest, unit) => {
             if (!lowest || unit.currentHp < lowest.currentHp) {
                 return unit;
             }


### PR DESCRIPTION
## Summary
- allow `TargetingManager.getLowestHpUnit` to accept a unit type string and fallback to current grid units
- no behavioral changes elsewhere

## Testing
- `npm test`
- `python3 -m http.server 8000 &` followed by `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878e80ded308327a852ff48b47f8024