### PR TITLE
Fix status effect lookup and skill range

### DIFF
--- a/js/managers/StatusEffectManager.js
+++ b/js/managers/StatusEffectManager.js
@@ -42,7 +42,7 @@ export class StatusEffectManager {
     }
 
     applyStatusEffect(unitId, statusEffectId) {
-        const effectData = STATUS_EFFECTS[statusEffectId.toUpperCase()];
+        const effectData = Object.values(STATUS_EFFECTS).find(effect => effect.id === statusEffectId);
         if (effectData) {
             this.turnCountManager.addEffect(unitId, effectData);
             this.eventManager.emit(GAME_EVENTS.STATUS_EFFECT_APPLIED, { unitId, statusEffectId, effectData }); // ✨ 상수 사용

--- a/js/managers/warriorSkillsAI.js
+++ b/js/managers/warriorSkillsAI.js
@@ -118,15 +118,22 @@ export class WarriorSkillsAI {
             const closestEnemy = this.managers.coordinateManager.findClosestUnit(userUnit.id, ATTACK_TYPES.ENEMY);
 
             if (closestEnemy) {
-                this.managers.eventManager.emit(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, {
-                    attackerId: userUnit.id,
-                    targetId: closestEnemy.id,
-                    attackType: ATTACK_TYPES.MELEE
-                });
+                const distance = Math.abs(userUnit.gridX - closestEnemy.gridX) + Math.abs(userUnit.gridY - closestEnemy.gridY);
+                const attackRange = userUnit.baseStats.attackRange || 1;
 
-                const normalAttackData = { type: ATTACK_TYPES.PHYSICAL, dice: skillData.effect.dice };
-                this.managers.battleCalculationManager.requestDamageCalculation(userUnit.id, closestEnemy.id, normalAttackData);
-                await this.managers.delayEngine.waitFor(500);
+                if (distance <= attackRange) {
+                    this.managers.eventManager.emit(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, {
+                        attackerId: userUnit.id,
+                        targetId: closestEnemy.id,
+                        attackType: ATTACK_TYPES.MELEE
+                    });
+
+                    const normalAttackData = { type: ATTACK_TYPES.PHYSICAL, dice: skillData.effect.dice };
+                    this.managers.battleCalculationManager.requestDamageCalculation(userUnit.id, closestEnemy.id, normalAttackData);
+                    await this.managers.delayEngine.waitFor(500);
+                } else if (GAME_DEBUG_MODE) {
+                    console.log(`[WarriorSkillsAI] Additional attack skipped. Target out of range (${distance} > ${attackRange}).`);
+                }
             } else {
                 console.log(`[WarriorSkillsAI] No target found for additional attack.`);
             }


### PR DESCRIPTION
## Summary
- search for status effects by `id` instead of upper‑casing keys
- avoid Battle Cry additional attacks when targets are out of range

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6878edebed648327acc19993105ff7e3