### PR TITLE
Implement RangeManager and monster refactor

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -26,56 +26,6 @@ export const CLASSES = {
         moveRange: 3, // 전사의 이동 거리
         tags: ['근접', '방어', '용병_클래스'] // ✨ 태그 추가
     },
-    // ✨ 새롭게 추가된 해골 클래스
-    SKELETON: {
-        id: 'class_skeleton',
-        name: '해골',
-        role: CLASS_ROLES.MELEE_DPS,
-        description: '다수로 몰려오는 기본적인 언데드 적.',
-        skills: ['skill_melee_attack'],
-        moveRange: 2, // 해골의 이동 거리(예시)
-        tags: ['근접', '언데드', '적_클래스'], // ✨ 태그 추가
-        // 기본 능력치. 몬스터 스폰 시 참조됩니다.
-        baseStats: {
-            hp: 60,
-            attack: 10,
-            defense: 4,
-            speed: 25,
-            valor: 0,
-            strength: 8,
-            endurance: 6,
-            agility: 8,
-            intelligence: 4,
-            wisdom: 4,
-            luck: 5,
-            weight: 8
-        }
-    },
-    // ✨ 좀비 클래스 추가
-    ZOMBIE: {
-        id: 'class_zombie',
-        name: '좀비',
-        role: CLASS_ROLES.MELEE_DPS,
-        description: '느릿느릿 움직이는 언데드.',
-        skills: ['skill_melee_attack'],
-        moveRange: 2,
-        tags: ['근접', '언데드', '적_클래스'],
-        // 기본 능력치 정의
-        baseStats: {
-            hp: 80,
-            attack: 15,
-            defense: 5,
-            speed: 30,
-            valor: 10,
-            strength: 10,
-            endurance: 8,
-            agility: 12,
-            intelligence: 5,
-            wisdom: 5,
-            luck: 15,
-            weight: 10
-        }
-    },
     // ✨ 전사 상위 클래스 추가
     WARRIOR_VALIANT: {
         id: 'class_warrior_valiant',

--- a/data/monsterClass.js
+++ b/data/monsterClass.js
@@ -1,0 +1,53 @@
+// data/monsterClass.js
+import { CLASS_ROLES } from './class.js';
+
+export const MONSTER_CLASSES = {
+    SKELETON: {
+        id: 'class_skeleton',
+        name: '해골',
+        role: CLASS_ROLES.MELEE_DPS,
+        description: '다수로 몰려오는 기본적인 언데드 적.',
+        skills: ['skill_melee_attack'],
+        moveRange: 2,
+        tags: ['근접', '언데드', '적_클래스'],
+        baseStats: {
+            hp: 60,
+            attack: 10,
+            defense: 4,
+            speed: 25,
+            valor: 0,
+            strength: 8,
+            endurance: 6,
+            agility: 8,
+            intelligence: 4,
+            wisdom: 4,
+            luck: 5,
+            weight: 8,
+            attackRange: 1
+        }
+    },
+    ZOMBIE: {
+        id: 'class_zombie',
+        name: '좀비',
+        role: CLASS_ROLES.MELEE_DPS,
+        description: '느릿느릿 움직이는 언데드.',
+        skills: ['skill_melee_attack'],
+        moveRange: 2,
+        tags: ['근접', '언데드', '적_클래스'],
+        baseStats: {
+            hp: 80,
+            attack: 15,
+            defense: 5,
+            speed: 30,
+            valor: 10,
+            strength: 10,
+            endurance: 8,
+            agility: 12,
+            intelligence: 5,
+            wisdom: 5,
+            luck: 15,
+            weight: 10,
+            attackRange: 1
+        }
+    }
+};

--- a/data/monsterUnit.js
+++ b/data/monsterUnit.js
@@ -1,0 +1,14 @@
+// data/monsterUnit.js
+import { UNIT_TYPES } from './unit.js';
+import { MONSTER_CLASSES } from './monsterClass.js';
+
+export const MONSTER_UNITS = {
+    ZOMBIE_DEFAULT: {
+        id: 'unit_zombie_default',
+        name: '좀비',
+        classId: MONSTER_CLASSES.ZOMBIE.id,
+        type: UNIT_TYPES.ENEMY,
+        spriteId: 'sprite_zombie_default'
+        // baseStats pulled from class data
+    }
+};

--- a/data/unit.js
+++ b/data/unit.js
@@ -28,7 +28,8 @@ export const UNITS = {
             intelligence: 5,
             wisdom: 10,
             luck: 15,
-            weight: 30
+            weight: 30,
+            attackRange: 1 // 기본 근접 사거리
         },
         spriteId: 'sprite_warrior_default',
         tags: ['용병', '남자'] // ✨ 유닛 자체의 태그

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -74,6 +74,9 @@ import { BattleFormationManager } from './managers/BattleFormationManager.js';
 import { MonsterSpawnManager } from './managers/MonsterSpawnManager.js';
 import { UnitStatManager } from './managers/UnitStatManager.js';
 import { StageDataManager } from './managers/StageDataManager.js';
+import { RangeManager } from './managers/RangeManager.js';
+import { MonsterEngine } from './managers/MonsterEngine.js';
+import { MonsterAI } from './managers/MonsterAI.js';
 
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';
@@ -156,6 +159,7 @@ export class GameEngine {
         // Managers that rely on BattleSimulationManager
         this.unitStatManager = new UnitStatManager(this.battleSimulationManager);
         this.stageDataManager = new StageDataManager();
+        this.rangeManager = new RangeManager(this.battleSimulationManager);
 
         // 2. CameraEngine 초기화 (ParticleEngine에서 사용)
         this.cameraEngine = new CameraEngine(this.renderer, this.logicManager, this.sceneEngine);
@@ -380,6 +384,10 @@ export class GameEngine {
         // ✨ BasicAIManager에 신규 매니저들 주입
         this.basicAIManager = new BasicAIManager(this.targetingManager, this.positionManager);
 
+        // Monster-related managers
+        this.monsterAI = new MonsterAI(this.basicAIManager);
+        this.monsterEngine = new MonsterEngine(this.monsterAI);
+
         // AI 와 턴 진행 관련 매니저들
         this.turnOrderManager = new TurnOrderManager(
             this.eventManager,
@@ -414,8 +422,9 @@ export class GameEngine {
             this.basicAIManager,
             this.warriorSkillsAI,
             this.diceEngine,
-            this.targetingManager, // 이미 주입되고 있었는지 확인
-            this.diceBotEngine
+            this.targetingManager,
+            this.diceBotEngine,
+            this.monsterAI
         );
 
         // ✨ TurnEngine에 새로운 의존성 전달
@@ -429,7 +438,8 @@ export class GameEngine {
             this.timingEngine,
             this.animationManager,
             this.battleCalculationManager,
-            this.statusEffectManager
+            this.statusEffectManager,
+            this.rangeManager
         );
 
         // ------------------------------------------------------------------
@@ -841,4 +851,7 @@ export class GameEngine {
     getPassiveIconManager() { return this.passiveIconManager; }
     getUnitStatManager() { return this.unitStatManager; }
     getStageDataManager() { return this.stageDataManager; }
+    getRangeManager() { return this.rangeManager; }
+    getMonsterEngine() { return this.monsterEngine; }
+    getMonsterAI() { return this.monsterAI; }
 }

--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -1,9 +1,9 @@
 // js/managers/ClassAIManager.js
 
-import { GAME_DEBUG_MODE } from '../constants.js';
+import { GAME_DEBUG_MODE, ATTACK_TYPES } from '../constants.js';
 
 export class ClassAIManager {
-    constructor(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager, diceBotEngine) {
+    constructor(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager, diceBotEngine, monsterAI) {
         console.log("\uD83D\uDD33 ClassAIManager initialized. Ready to define class-based AI. \uD83D\uDD33");
         this.idManager = idManager;
         this.battleSimulationManager = battleSimulationManager;
@@ -13,6 +13,7 @@ export class ClassAIManager {
         this.diceEngine = diceEngine;
         this.targetingManager = targetingManager;
         this.diceBotEngine = diceBotEngine;
+        this.monsterAI = monsterAI;
     }
 
     /**
@@ -26,6 +27,11 @@ export class ClassAIManager {
         if (!unitClass) {
             console.warn(`[ClassAIManager] Class data not found for unit ${unit.name} (${unit.classId}). Cannot determine action.`);
             return null;
+        }
+
+        // 적 유닛이라면 MonsterAI에 위임
+        if (unit.type === ATTACK_TYPES.ENEMY) {
+            return this.monsterAI.getMeleeAIAction(unit, allUnits);
         }
 
         // 1. 결정된 스킬이 있는지 먼저 확인

--- a/js/managers/MonsterAI.js
+++ b/js/managers/MonsterAI.js
@@ -1,0 +1,25 @@
+// js/managers/MonsterAI.js
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * Defines behaviour patterns for monsters.
+ */
+export class MonsterAI {
+    constructor(basicAIManager) {
+        if (GAME_DEBUG_MODE) console.log("\uD83E\uDDDF MonsterAI initialized.");
+        this.basicAIManager = basicAIManager;
+    }
+
+    /**
+     * Use basic melee AI shared with warriors.
+     * @param {object} monsterUnit
+     * @param {object[]} allUnits
+     */
+    getMeleeAIAction(monsterUnit, allUnits) {
+        if (!monsterUnit) return null;
+        const moveRange = monsterUnit.baseStats.moveRange || 1;
+        const attackRange = monsterUnit.baseStats.attackRange || 1;
+        if (GAME_DEBUG_MODE) console.log(`[MonsterAI] Delegating ${monsterUnit.name}`);
+        return this.basicAIManager.determineMoveAndTarget(monsterUnit, moveRange, attackRange);
+    }
+}

--- a/js/managers/MonsterEngine.js
+++ b/js/managers/MonsterEngine.js
@@ -1,0 +1,22 @@
+// js/managers/MonsterEngine.js
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * Top level engine responsible for monster-related behaviour.
+ */
+export class MonsterEngine {
+    constructor(monsterAI) {
+        if (GAME_DEBUG_MODE) console.log("\uD83E\uDD16 MonsterEngine initialized.");
+        this.monsterAI = monsterAI;
+    }
+
+    /**
+     * Determine an action for the monster via MonsterAI.
+     * @param {object} monsterUnit
+     * @param {object[]} allUnits
+     * @returns {object|null}
+     */
+    determineAction(monsterUnit, allUnits) {
+        return this.monsterAI.getMeleeAIAction(monsterUnit, allUnits);
+    }
+}

--- a/js/managers/MonsterSpawnManager.js
+++ b/js/managers/MonsterSpawnManager.js
@@ -1,6 +1,7 @@
 // js/managers/MonsterSpawnManager.js
 
 import { ATTACK_TYPES } from '../constants.js';
+import { MONSTER_CLASSES } from '../../data/monsterClass.js';
 
 // StageDataManager will provide monster layouts
 
@@ -24,7 +25,7 @@ export class MonsterSpawnManager {
             return;
         }
 
-        const zombieClassData = await this.idManager.get('class_zombie');
+        const zombieClassData = MONSTER_CLASSES.ZOMBIE;
         const zombieImage = this.assetLoaderManager.getImage('sprite_zombie_default');
 
         if (!zombieClassData || !zombieClassData.baseStats) {

--- a/js/managers/RangeManager.js
+++ b/js/managers/RangeManager.js
@@ -1,0 +1,41 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * Calculates attack ranges and checks if targets are in range.
+ */
+export class RangeManager {
+    constructor(battleSimulationManager) {
+        if (GAME_DEBUG_MODE) console.log("\uD83D\uDCCF RangeManager initialized.");
+        this.battleSimulationManager = battleSimulationManager;
+    }
+
+    /**
+     * Returns the attack range for a unit.
+     * @param {object} unit
+     * @returns {number}
+     */
+    getAttackRange(unit) {
+        if (unit && unit.baseStats && unit.baseStats.attackRange) {
+            return unit.baseStats.attackRange;
+        }
+        return 1;
+    }
+
+    /**
+     * Determines whether the target is within the attacker's range.
+     * @param {object} attacker
+     * @param {object} target
+     * @returns {boolean}
+     */
+    isTargetInRange(attacker, target) {
+        if (!attacker || !target) return false;
+        const attackRange = this.getAttackRange(attacker);
+        const distance = Math.abs(attacker.gridX - target.gridX) + Math.abs(attacker.gridY - target.gridY);
+        const inRange = distance <= attackRange;
+        if (GAME_DEBUG_MODE) {
+            const msg = inRange ? 'IN RANGE' : 'OUT OF RANGE';
+            console.log(`[RangeManager] Target ${target.name} is ${msg} for ${attacker.name}. (Dist: ${distance}, Range: ${attackRange})`);
+        }
+        return inRange;
+    }
+}

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -4,7 +4,7 @@
 import { GAME_EVENTS, UI_STATES, ATTACK_TYPES, GAME_DEBUG_MODE } from '../constants.js';
 
 export class TurnEngine {
-    constructor(eventManager, battleSimulationManager, turnOrderManager, microcosmHeroEngine, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager, statusEffectManager) {
+    constructor(eventManager, battleSimulationManager, turnOrderManager, microcosmHeroEngine, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager, statusEffectManager, rangeManager) {
         if (GAME_DEBUG_MODE) console.log("\uD83D\uDD01 TurnEngine initialized. Ready to manage game turns. \uD83D\uDD01");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
@@ -16,6 +16,7 @@ export class TurnEngine {
         this.animationManager = animationManager;
         this.battleCalculationManager = battleCalculationManager;
         this.statusEffectManager = statusEffectManager;
+        this.rangeManager = rangeManager;
 
         this.currentTurn = 0;
         this.activeUnitIndex = -1;
@@ -154,7 +155,7 @@ export class TurnEngine {
                     if (action.actionType === 'attack' || action.actionType === 'moveAndAttack') {
                         if (action.targetId) {
                             const targetUnit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === action.targetId);
-                            if (targetUnit && targetUnit.currentHp > 0) {
+                            if (targetUnit && targetUnit.currentHp > 0 && this.rangeManager.isTargetInRange(unit, targetUnit)) {
                                 if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Unit ${unit.name} attacks ${targetUnit.name}!`);
                                 this.eventManager.emit(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, { // ✨ 상수 사용
                                     attackerId: unit.id,
@@ -165,7 +166,7 @@ export class TurnEngine {
                                 this.battleCalculationManager.requestDamageCalculation(unit.id, targetUnit.id, defaultAttackSkillData);
                                 await this.delayEngine.waitFor(500);
                             } else {
-                                if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Target ${action.targetId} is no longer valid for attack.`);
+                                if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Target ${action.targetId} is no longer valid or out of range.`);
                             }
                         }
                     } else if (action.actionType === 'skill') {


### PR DESCRIPTION
## Summary
- add `RangeManager` for distance checking
- move undead class data into new `monsterClass.js`
- introduce `MonsterEngine` and `MonsterAI`
- update class and unit data with `attackRange`
- integrate range checks and monster AI into existing systems

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878f04036cc8327b852a865a368db0b