### PR TITLE
Fix BasicAI movement

### DIFF
--- a/js/managers/BasicAIManager.js
+++ b/js/managers/BasicAIManager.js
@@ -48,10 +48,18 @@ export class BasicAIManager {
         );
         if (pathToTarget && pathToTarget.length > 1) {
             // 이동 가능한 최대 거리 내에서 적에게 가장 근접한 위치를 찾음
-            const maxReachableIndex = Math.min(pathToTarget.length - 2, moveRange);
-            const moveDestination = pathToTarget[maxReachableIndex];
+            const maxReachableIndex = Math.min(moveRange, pathToTarget.length - 1);
 
-            if (moveDestination && !this.positionManager.battleSimulationManager.isTileOccupied(moveDestination.x, moveDestination.y, unit.id)) {
+            let moveDestination = null;
+            for (let i = maxReachableIndex; i > 0; i--) {
+                const candidate = pathToTarget[i];
+                if (!this.positionManager.battleSimulationManager.isTileOccupied(candidate.x, candidate.y, unit.id)) {
+                    moveDestination = candidate;
+                    break;
+                }
+            }
+
+            if (moveDestination) {
                 if (GAME_DEBUG_MODE) console.log(`[BasicAIManager] ${unit.name} cannot reach attack position. Moving towards ${target.name} at (${moveDestination.x},${moveDestination.y}).`);
                 return { actionType: 'move', moveTargetX: moveDestination.x, moveTargetY: moveDestination.y };
             }

--- a/tests/unit/basicAIManagerUnitTests.js
+++ b/tests/unit/basicAIManagerUnitTests.js
@@ -72,7 +72,7 @@ export function runBasicAIManagerUnitTests(battleSimulationManager) {
     try {
         const basicAIManager = new BasicAIManager(battleSimulationManager);
         const action = basicAIManager.determineMoveAndTarget(mockWarrior, battleSimulationManager.unitsOnGrid, 3, 1);
-        if (action && action.actionType === 'move' && action.moveTargetX === 3 && action.moveTargetY === 0) {
+        if (action && action.actionType === 'move' && action.moveTargetX === 2 && action.moveTargetY === 0) {
             console.log("BasicAIManager: Determined 'move' towards distant target. [PASS]");
             passCount++;
         } else {


### PR DESCRIPTION
## Summary
- allow AI to move multiple tiles towards target without occupying enemy tile
- adjust unit test expectation for new movement logic

## Testing
- `npm test`
- `python3 -m http.server 8000 &`; `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878fe7ad9b0832798160ca68c6e1171