### PR TITLE
Fix movement range and judgement timing

### DIFF
--- a/js/managers/HeroEngine.js
+++ b/js/managers/HeroEngine.js
@@ -1,4 +1,5 @@
 // js/managers/HeroEngine.js
+import { CLASSES } from '../../data/class.js';
 
 export class HeroEngine {
     /**
@@ -87,6 +88,10 @@ export class HeroEngine {
             weight: this.diceEngine.getRandomInt(10, 40),
             speed: this.diceEngine.getRandomInt(30, 90)
         };
+
+        const classData = Object.values(CLASSES).find(c => c.id === classId);
+        baseStats.moveRange = classData?.moveRange || 1;
+        baseStats.attackRange = classData?.attackRange || 1;
 
         // 3. 랜덤한 세 가지 스킬 부여 (임시 스킬 ID 사용)
         const skills = [

--- a/js/managers/MonsterSpawnManager.js
+++ b/js/managers/MonsterSpawnManager.js
@@ -48,7 +48,10 @@ export class MonsterSpawnManager {
                     spriteId: 'sprite_zombie_default',
                     gridX: pos.x,
                     gridY: pos.y,
-                    baseStats: { ...(zombieClassData.baseStats || {}) },
+                    baseStats: {
+                        ...(zombieClassData.baseStats || {}),
+                        moveRange: zombieClassData.moveRange || 1
+                    },
                     currentHp: zombieClassData.baseStats.hp,
                     skillSlots: [...(zombieClassData.skills || [])]
                 };

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -182,10 +182,10 @@ export class TurnEngine {
             for (const callback of this.turnPhaseCallbacks.unitActions) {
                 await callback(unit);
             }
-            this.eventManager.emit(GAME_EVENTS.UNIT_TURN_END, { unitId: unit.id, unitName: unit.name }); // ✨ 상수 사용
-
             await this.timingEngine.processActions();
             this.timingEngine.clearActions();
+
+            this.eventManager.emit(GAME_EVENTS.UNIT_TURN_END, { unitId: unit.id, unitName: unit.name }); // ✨ 상수 사용
         }
 
         this.eventManager.emit(GAME_EVENTS.TURN_PHASE, { phase: 'endOfTurn', turn: this.currentTurn });


### PR DESCRIPTION
## Summary
- give heroes and zombies proper `moveRange`
- delay unit turn end events until after actions complete
- wire up class move and attack ranges during hero generation

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878fe7ad9b0832798160ca68c6e1171