### PR TITLE
Include moveRange in warrior base stats

### DIFF
--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -55,7 +55,10 @@ export class HeroManager {
                 spriteId: UNITS.WARRIOR.spriteId,
                 gridX: 0,
                 gridY: 0,
-                baseStats: { ...UNITS.WARRIOR.baseStats },
+                baseStats: {
+                    ...UNITS.WARRIOR.baseStats,
+                    moveRange: warriorClassData.moveRange || 1
+                },
                 currentHp: UNITS.WARRIOR.baseStats.hp,
                 skillSlots: [...randomSkills],
                 tags: [...CLASSES.WARRIOR.tags]


### PR DESCRIPTION
## Summary
- fix `HeroManager.createWarriors` so generated warriors inherit `moveRange` from the Warrior class

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687903f4bcb48327b2e73a45cba9641d