### PR TITLE
Add skill name display VFX

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -1,6 +1,7 @@
 export const GAME_EVENTS = {
     UNIT_DEATH: 'unitDeath',
     SKILL_EXECUTED: 'skillExecuted',
+    DISPLAY_SKILL_NAME: 'displaySkillName', // 스킬 이름 표시 요청 이벤트
     BATTLE_START: 'battleStart',
     BATTLE_END: 'battleEnd',
     TURN_START: 'turnStart',

--- a/js/managers/ReactionSkillManager.js
+++ b/js/managers/ReactionSkillManager.js
@@ -48,6 +48,12 @@ export class ReactionSkillManager {
         if (this.diceEngine.getRandomFloat() < skillData.effect.probability) {
             if (GAME_DEBUG_MODE) console.log(`[ReactionSkillManager] ${defender.name}'s Retaliate triggered against ${attackerId}!`);
 
+            // 스킬 이름 표시 이벤트 발생
+            this.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
+                unitId: defenderId,
+                skillName: skillData.name
+            });
+
             await this.delayEngine.waitFor(250);
 
             this.eventManager.emit(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, {

--- a/js/managers/warriorSkillsAI.js
+++ b/js/managers/warriorSkillsAI.js
@@ -37,6 +37,12 @@ export class WarriorSkillsAI {
         }
         if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${userUnit.name} uses ${skillData.name}!`);
 
+        // 스킬 이름 표시 이벤트
+        this.managers.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
+            unitId: userUnit.id,
+            skillName: skillData.name
+        });
+
         // 1. 스킬 시전 시각 효과
         this.managers.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, {
             skillId: skillData.id,
@@ -99,6 +105,10 @@ export class WarriorSkillsAI {
         if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${userUnit.name} attempts ${skillData.name} on ${targetUnit.name}!`);
 
         if (skillData.effect.applyChance && this.managers.diceEngine.getRandomFloat() < skillData.effect.applyChance) {
+            this.managers.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
+                unitId: userUnit.id,
+                skillName: skillData.name
+            });
             this.managers.workflowManager.triggerStatusEffectApplication(targetUnit.id, skillData.effect.statusEffectId);
             await this.managers.delayEngine.waitFor(100);
             if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${targetUnit.name} is now bleeding!`);


### PR DESCRIPTION
## Summary
- add `DISPLAY_SKILL_NAME` game event
- extend `VFXManager` to show floating skill names
- trigger skill name display on retaliate and warrior skills

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68790b9879ec832798d165bb8c41b4c7