### PR TITLE
Add hero registration workflow

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -479,7 +479,8 @@ export class GameEngine {
             this.battleSimulationManager,
             this.unitSpriteEngine,
             this.diceBotEngine,
-            this.birthReportManager
+            this.birthReportManager,
+            this.heroEngine
         );
 
         this.battleFormationManager = new BattleFormationManager(this.battleSimulationManager);

--- a/js/managers/HeroEngine.js
+++ b/js/managers/HeroEngine.js
@@ -34,7 +34,7 @@ export class HeroEngine {
         await this.assetLoaderManager.loadImage('hero_default_healer_image', 'assets/images/healer.png');
 
         // 예시로 영웅 몇 명을 미리 생성 (실제는 가챠 시스템이 호출)
-        const warriorHero = await this.generateHero({
+        await this.generateHero({
             heroId: 'hero_warrior_001',
             name: '강철 주먹 라이언',
             classId: 'class_warrior',
@@ -42,7 +42,7 @@ export class HeroEngine {
             rarity: 'rare'
         });
 
-        const archerHero = await this.generateHero({
+        await this.generateHero({
             heroId: 'hero_archer_001',
             name: '매의 눈 레오나',
             classId: 'class_archer',
@@ -50,10 +50,25 @@ export class HeroEngine {
             rarity: 'uncommon'
         });
 
-        if (warriorHero) this.heroes.set(warriorHero.id, warriorHero);
-        if (archerHero) this.heroes.set(archerHero.id, archerHero);
-
         console.log(`[HeroEngine] Loaded ${this.heroes.size} basic heroes.`);
+    }
+
+    /**
+     * HeroManager 등 외부에서 생성된 영웅 데이터를 받아 등록합니다.
+     * @param {object} heroData - 등록할 영웅의 전체 데이터
+     */
+    async addHero(heroData) {
+        if (!heroData || !heroData.id) {
+            console.error('[HeroEngine] Cannot add hero. Invalid heroData provided.');
+            return;
+        }
+        if (this.heroes.has(heroData.id)) {
+            console.warn(`[HeroEngine] Hero with ID '${heroData.id}' already exists. Overwriting.`);
+        }
+
+        await this.microcosmHeroEngine.createHeroMicrocosm(heroData);
+        this.heroes.set(heroData.id, heroData);
+        console.log(`[HeroEngine] Registered existing hero: ${heroData.name} (${heroData.id})`);
     }
 
 
@@ -138,9 +153,8 @@ export class HeroEngine {
             maxBarrier: 0
         };
 
-        await this.microcosmHeroEngine.createHeroMicrocosm(newHero);
+        await this.addHero(newHero);
 
-        this.heroes.set(heroId, newHero);
         console.log(`[HeroEngine] Generated new hero: ${newHero.name} (${newHero.id})`);
         return newHero;
     }

--- a/js/managers/HeroManager.js
+++ b/js/managers/HeroManager.js
@@ -6,7 +6,7 @@ import { CLASSES } from '../../data/class.js';
 import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 
 export class HeroManager {
-    constructor(idManager, diceEngine, assetLoaderManager, battleSimulationManager, unitSpriteEngine, diceBotEngine, birthReportManager) {
+    constructor(idManager, diceEngine, assetLoaderManager, battleSimulationManager, unitSpriteEngine, diceBotEngine, birthReportManager, heroEngine) {
         if (GAME_DEBUG_MODE) console.log("\u2728 HeroManager initialized. Ready to create legendary heroes. \u2728");
         this.idManager = idManager;
         this.diceEngine = diceEngine;
@@ -15,6 +15,7 @@ export class HeroManager {
         this.unitSpriteEngine = unitSpriteEngine;
         this.diceBotEngine = diceBotEngine;
         this.birthReportManager = birthReportManager;
+        this.heroEngine = heroEngine;
         this.heroNameList = [
             '레오닉', '아서스', '가로쉬', '스랄', '제이나', '안두인',
             '바리안', '실바나스', '그롬마쉬', '렉사르', '알렉스트라자', '이렐리아'
@@ -75,6 +76,10 @@ export class HeroManager {
 
             if (this.birthReportManager) {
                 this.birthReportManager.report(heroUnitData);
+            }
+
+            if (this.heroEngine) {
+                await this.heroEngine.addHero(heroUnitData);
             }
 
             createdHeroes.push(heroUnitData);


### PR DESCRIPTION
## Summary
- allow HeroEngine to register heroes from external sources
- include hero engine into HeroManager to register warriors
- pass hero engine when constructing HeroManager

## Testing
- `npm test`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68790e7462148327a0d5146a67cc418f