### PR TITLE
Add SoundEngine manager

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -110,6 +110,7 @@
         <button id="runWarriorSkillsAIUnitTestsBtn">WarriorSkillsAI 유닛 테스트</button>
         <button id="runShadowEngineUnitTestsBtn">ShadowEngine 유닛 테스트</button>
         <button id="runMicrocosmHeroEngineUnitTestsBtn">MicrocosmHeroEngine 유닛 테스트</button>
+        <button id="runSoundEngineUnitTestsBtn">SoundEngine 유닛 테스트</button>
 
         <h4>엔진 결함 주입 테스트</h4>
         <button id="injectRendererFaultBtn" class="fault-btn">렌더러 결함 주입</button>
@@ -200,7 +201,8 @@
             runSkillIconManagerUnitTests,
             runStatusIconManagerUnitTests,
             runShadowEngineUnitTests,
-            runMicrocosmHeroEngineUnitTests
+            runMicrocosmHeroEngineUnitTests,
+            runSoundEngineUnitTests
     } from './tests/index.js';
     import { STATUS_EFFECTS } from './data/statusEffects.js';
     // ✨ 상수 파일 임포트
@@ -454,6 +456,9 @@
             });
             document.getElementById('runMicrocosmHeroEngineUnitTestsBtn').addEventListener('click', () => {
                 runMicrocosmHeroEngineUnitTests();
+            });
+            document.getElementById('runSoundEngineUnitTestsBtn').addEventListener('click', () => {
+                runSoundEngineUnitTests();
             });
             document.getElementById('injectRendererFaultBtn').addEventListener('click', () => {
                 injectRendererFault(renderer);

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -38,6 +38,7 @@ import { TurnOrderManager } from './managers/TurnOrderManager.js'; // ✨ 새롭
 import { ClassAIManager } from './managers/ClassAIManager.js';   // ✨ 새롭게 추가
 import { BasicAIManager } from './managers/BasicAIManager.js'; // ✨ 새롭게 추가
 import { TargetingManager } from './managers/TargetingManager.js'; // ✨ TargetingManager 추가
+import { SoundEngine } from './managers/SoundEngine.js'; // SoundEngine 임포트 추가
 import { PositionManager } from './managers/PositionManager.js'; // ✨ PositionManager 추가
 import { JudgementManager } from './managers/JudgementManager.js'; // JudgementManager 임포트
 import { ValorEngine } from './managers/ValorEngine.js';   // ✨ ValorEngine 추가
@@ -108,6 +109,7 @@ export class GameEngine {
         this.guardianManager = new GuardianManager();
         this.measureManager = new MeasureManager();
         this.ruleManager = new RuleManager();
+        this.soundEngine = new SoundEngine(); // <-- SoundEngine 인스턴스 생성
 
         // ------------------------------------------------------------------
         // 2. Scene & Logic Managers
@@ -862,4 +864,5 @@ export class GameEngine {
     getRangeManager() { return this.rangeManager; }
     getMonsterEngine() { return this.monsterEngine; }
     getMonsterAI() { return this.monsterAI; }
+    getSoundEngine() { return this.soundEngine; }
 }

--- a/js/managers/SoundEngine.js
+++ b/js/managers/SoundEngine.js
@@ -1,0 +1,121 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * 게임의 모든 사운드(BGM, 효과음)를 로드하고 재생하며 제어하는 엔진입니다.
+ * Web Audio API를 사용하여 정교한 사운드 컨트롤을 제공합니다.
+ */
+export class SoundEngine {
+    constructor() {
+        try {
+            // 웹 오디오 컨텍스트를 생성합니다. 모든 오디오 작업의 시작점입니다.
+            this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+            
+            // 전체 볼륨을 제어하는 마스터 게인 노드
+            this.masterGainNode = this.audioContext.createGain();
+            this.masterGainNode.connect(this.audioContext.destination);
+
+            // BGM 전용 볼륨 제어 노드
+            this.bgmGainNode = this.audioContext.createGain();
+            this.bgmGainNode.connect(this.masterGainNode);
+
+            // 효과음(SFX) 전용 볼륨 제어 노드
+            this.sfxGainNode = this.audioContext.createGain();
+            this.sfxGainNode.connect(this.masterGainNode);
+
+            this.audioCache = new Map(); // 로드된 오디오 데이터를 캐시하는 맵
+            this.playingSources = new Map(); // 현재 재생 중인 사운드 소스를 관리
+
+            if (GAME_DEBUG_MODE) console.log("\ud83d\udd0a SoundEngine initialized successfully using Web Audio API.");
+        } catch (e) {
+            console.error("SoundEngine: Web Audio API is not supported in this browser.", e);
+            // Web Audio API를 지원하지 않는 브라우저에서는 오디오 기능이 비활성화됩니다.
+            this.audioContext = null;
+        }
+    }
+
+    /**
+     * 사운드 파일을 비동기적으로 로드하고 디코딩하여 캐시에 저장합니다.
+     * @param {string} id - 사운드를 식별할 고유 ID (예: 'sfx_sword_swing')
+     * @param {string} url - 사운드 파일의 경로
+     * @returns {Promise<void>}
+     */
+    async loadSound(id, url) {
+        if (!this.audioContext) return;
+        if (this.audioCache.has(id)) {
+            if (GAME_DEBUG_MODE) console.log(`[SoundEngine] Sound '${id}' is already cached.`);
+            return;
+        }
+
+        try {
+            const response = await fetch(url);
+            const arrayBuffer = await response.arrayBuffer();
+            const audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
+            this.audioCache.set(id, audioBuffer);
+            if (GAME_DEBUG_MODE) console.log(`[SoundEngine] Sound '${id}' loaded and cached from ${url}.`);
+        } catch (error) {
+            console.error(`[SoundEngine] Error loading sound '${id}' from ${url}:`, error);
+        }
+    }
+
+    /**
+     * 캐시된 사운드를 재생합니다.
+     * @param {string} id - 재생할 사운드의 ID
+     * @param {object} options - 재생 옵션 { loop, volume, type }
+     * @returns {string | null} 재생 중인 사운드를 제어하기 위한 고유 소스 ID 또는 null
+     */
+    playSound(id, { loop = false, volume = 1.0, type = 'sfx' } = {}) {
+        if (!this.audioContext || !this.audioCache.has(id)) {
+            if (GAME_DEBUG_MODE) console.warn(`[SoundEngine] Sound '${id}' not found or AudioContext not available.`);
+            return null;
+        }
+
+        const source = this.audioContext.createBufferSource();
+        source.buffer = this.audioCache.get(id);
+        source.loop = loop;
+
+        const gainNode = this.audioContext.createGain();
+        gainNode.gain.setValueAtTime(volume, this.audioContext.currentTime);
+
+        const destination = type === 'bgm' ? this.bgmGainNode : this.sfxGainNode;
+        source.connect(gainNode).connect(destination);
+        source.start(0);
+
+        const sourceId = `source_${Date.now()}_${Math.random()}`;
+        this.playingSources.set(sourceId, { source, gainNode });
+
+        source.onended = () => {
+            this.playingSources.delete(sourceId);
+        };
+
+        if (GAME_DEBUG_MODE) console.log(`[SoundEngine] Playing sound '${id}' (type: ${type}).`);
+        return sourceId;
+    }
+
+    /**
+     * 특정 사운드의 재생을 중지합니다.
+     * @param {string} sourceId - playSound가 반환한 소스 ID
+     */
+    stopSound(sourceId) {
+        if (this.playingSources.has(sourceId)) {
+            const { source } = this.playingSources.get(sourceId);
+            try {
+                source.stop(0);
+            } catch(e) {
+                // 이미 재생이 끝난 경우 오류가 발생할 수 있으므로 무시합니다.
+            }
+            this.playingSources.delete(sourceId);
+            if (GAME_DEBUG_MODE) console.log(`[SoundEngine] Stopped sound with sourceId '${sourceId}'.`);
+        }
+    }
+    
+    /**
+     * 마스터 볼륨을 조절합니다 (0.0 ~ 1.0).
+     * @param {number} volume 
+     */
+    setMasterVolume(volume) {
+        if (this.masterGainNode) {
+            this.masterGainNode.gain.setValueAtTime(volume, this.audioContext.currentTime);
+            if (GAME_DEBUG_MODE) console.log(`[SoundEngine] Master volume set to ${volume}.`);
+        }
+    }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,6 +14,7 @@ export { runMovingManagerUnitTests } from './unit/movingManagerUnitTests.js'; //
 export { runWarriorSkillsAIUnitTests } from './unit/warriorSkillsAIUnitTests.js'; // ✨ WarriorSkillsAI 테스트 임포트 확인
 export { runShadowEngineUnitTests } from './unit/shadowEngineUnitTests.js'; // ✨ ShadowEngine 단위 테스트 추가
 export { runMicrocosmHeroEngineUnitTests } from './unit/microcosmHeroEngineUnitTests.js'; // 👈 추가
+export { runSoundEngineUnitTests } from './unit/soundEngineUnitTests.js'; // <-- 이 줄 추가
 
 // new unit tests
 export { runSceneEngineUnitTests } from './unit/sceneEngineUnitTests.js';

--- a/tests/unit/soundEngineUnitTests.js
+++ b/tests/unit/soundEngineUnitTests.js
@@ -1,0 +1,41 @@
+import { SoundEngine } from '../../js/managers/SoundEngine.js';
+import { GAME_DEBUG_MODE } from '../../js/constants.js';
+
+export function runSoundEngineUnitTests() {
+    if (!GAME_DEBUG_MODE) return;
+    console.log("--- SoundEngine Unit Test Start ---");
+
+    // Test 1: Initialization
+    try {
+        const soundEngine = new SoundEngine();
+        if (soundEngine.audioContext) {
+            console.log("SoundEngine: Initialized correctly with AudioContext. [PASS]");
+        } else {
+            console.warn("SoundEngine: AudioContext not supported, skipping tests. [SKIP]");
+            return;
+        }
+    } catch (e) {
+        console.error("SoundEngine: Error during initialization. [FAIL]", e);
+        return;
+    }
+
+    // A silent 1-second WAV file represented as a data URL for testing
+    const mockAudioURL = 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=';
+
+    // Test 2: loadSound
+    (async () => {
+        const soundEngine = new SoundEngine();
+        if (!soundEngine.audioContext) return;
+
+        try {
+            await soundEngine.loadSound('test_sfx', mockAudioURL);
+            if (soundEngine.audioCache.has('test_sfx')) {
+                console.log("SoundEngine: loadSound successfully loaded and cached audio. [PASS]");
+            } else {
+                console.error("SoundEngine: loadSound failed to cache audio. [FAIL]");
+            }
+        } catch (e) {
+            console.error("SoundEngine: Error during loadSound test. [FAIL]", e);
+        }
+    })();
+}


### PR DESCRIPTION
## Summary
- implement `SoundEngine` for handling audio playback with Web Audio API
- wire the engine into `GameEngine`
- provide unit tests for SoundEngine
- expose new test through `tests/index.js` and `debug.html`

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687931e84f3c8327beaa590f89208989