### PR TITLE
Load skill icons from data definitions

### DIFF
--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -57,6 +57,7 @@ export const WARRIOR_SKILLS = {
         name: '더블 스트라이크',
         description: '한 대상에게 빠르게 일반 공격을 2회 가합니다.',
         type: SKILL_TYPES.ACTIVE,
+        icon: 'assets/icons/skills/double-strike-icon.png',
         cost: 25,
         range: 1,
         cooldown: 2,

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -635,8 +635,8 @@ export class GameEngine {
         }
         if (GAME_DEBUG_MODE) console.log(`[GameEngine] Registered ${Object.keys(WARRIOR_SKILLS).length} warrior skills.`);
 
-        // ✨ SkillIconManager의 기본 아이콘 로드를 시작
-        await this.skillIconManager._loadDefaultSkillIcons();
+        // ✨ SkillIconManager의 아이콘 로드를 시작합니다.
+        await this.skillIconManager._loadAllIcons();
         if (GAME_DEBUG_MODE) console.log("[GameEngine] All initial icons have been queued for loading by SkillIconManager.");
 
         // 2. AssetLoaderManager로 전사 스프라이트 로드

--- a/tests/unit/skillIconManagerUnitTests.js
+++ b/tests/unit/skillIconManagerUnitTests.js
@@ -39,24 +39,24 @@ export function runSkillIconManagerUnitTests(assetLoaderManager, idManager) {
     testCount++;
     try {
         const sim = new SkillIconManager(mockAssetLoaderManager, mockIdManager);
-        await sim._loadDefaultSkillIcons();
-        const expectedIconCount = 5 + 5;
-        if (sim.skillIcons.size === expectedIconCount && sim.skillIcons.has('skill_warrior_battle_cry')) {
-            console.log("SkillIconManager: _loadDefaultSkillIcons loaded icons correctly. [PASS]");
+        await sim._loadAllIcons();
+        const expectedIconCount = 1; // 현재 아이콘이 정의된 스킬 수
+        if (sim.skillIcons.size === expectedIconCount && sim.skillIcons.has('skill_warrior_double_strike')) {
+            console.log("SkillIconManager: _loadAllIcons loaded icons correctly. [PASS]");
             passCount++;
         } else {
-            console.error(`SkillIconManager: _loadDefaultSkillIcons failed. Expected ${expectedIconCount} icons, got ${sim.skillIcons.size}. [FAIL]`);
+            console.error(`SkillIconManager: _loadAllIcons failed. Expected ${expectedIconCount} icons, got ${sim.skillIcons.size}. [FAIL]`);
         }
     } catch (e) {
-        console.error("SkillIconManager: Error during _loadDefaultSkillIcons test. [FAIL]", e);
+        console.error("SkillIconManager: Error during _loadAllIcons test. [FAIL]", e);
     }
 
     testCount++;
     try {
         const sim = new SkillIconManager(mockAssetLoaderManager, mockIdManager);
-        await sim._loadDefaultSkillIcons();
-        const icon = sim.getSkillIcon('skill_warrior_battle_cry');
-        if (icon && icon.src && icon.src.includes('battle_cry.png')) {
+        await sim._loadAllIcons();
+        const icon = sim.getSkillIcon('skill_warrior_double_strike');
+        if (icon && icon.src && icon.src.includes('double-strike-icon.png')) {
             console.log("SkillIconManager: getSkillIcon returned correct icon. [PASS]");
             passCount++;
         } else {
@@ -69,7 +69,7 @@ export function runSkillIconManagerUnitTests(assetLoaderManager, idManager) {
     testCount++;
     try {
         const sim = new SkillIconManager(mockAssetLoaderManager, mockIdManager);
-        await sim._loadDefaultSkillIcons();
+        await sim._loadAllIcons();
         const icon = sim.getSkillIcon('non_existent_skill_icon');
         if (icon && icon.src && icon.src.startsWith('data:image')) {
             console.log("SkillIconManager: getSkillIcon returned placeholder for non-existent icon. [PASS]");


### PR DESCRIPTION
## Summary
- add icon path to warrior double strike skill
- load skill and status icons dynamically from data
- call skill icon loader from GameEngine
- update SkillIconManager unit test

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68793b673d888327b7c14ba0680c6606