### PR TITLE
Add Stone Skin buff with damage reduction

### DIFF
--- a/data/statusEffects.js
+++ b/data/statusEffects.js
@@ -62,6 +62,20 @@ export const STATUS_EFFECTS = {
         }
     },
 
+    STONE_SKIN: {
+        id: 'status_stone_skin',
+        name: '스톤 스킨',
+        type: STATUS_EFFECT_TYPES.BUFF,
+        duration: 3,
+        icon: 'assets/icons/skills/stone-skin-icon.png',
+        effect: {
+            tags: ['방어', '피해감소'],
+            statModifiers: {
+                damageReduction: 0.15
+            }
+        }
+    },
+
     // ✨ 새롭게 추가된 '무장해제' 상태 이상
     DISARMED: {
         id: 'status_disarmed',

--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -70,6 +70,24 @@ export const WARRIOR_SKILLS = {
             condition: (user, target) => target && user.getDistanceTo && user.getDistanceTo(target) <= 1
         }
     },
+    STONE_SKIN: {
+        id: 'skill_warrior_stone_skin',
+        name: '스톤 스킨',
+        description: '3턴 동안 받는 모든 피해가 15% 감소합니다.',
+        type: 'active',
+        icon: 'assets/icons/skills/stone-skin-icon.png',
+        cost: 20,
+        range: 0,
+        cooldown: 4,
+        effect: {
+            tags: ['방어', '버프'],
+            appliesEffect: 'status_stone_skin'
+        },
+        ai: {
+            usageChance: 0.3,
+            condition: (user, target) => user.currentHp / user.baseStats.hp <= 0.5
+        }
+    },
     // 패시브 스킬 (상시 발동 예시)
     IRON_WILL: {
         id: 'skill_warrior_iron_will',

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -358,6 +358,8 @@ export class GameEngine {
             this.battleCalculationManager
         );
 
+        this.battleCalculationManager.statusEffectManager = this.statusEffectManager;
+
         // 이제 StatusEffectManager가 준비되었으므로 DiceRollManager를 생성
         this.diceRollManager = new DiceRollManager(this.diceEngine, this.valorEngine, this.statusEffectManager);
         this.battleCalculationManager.diceRollManager = this.diceRollManager;
@@ -495,7 +497,12 @@ export class GameEngine {
         // ------------------------------------------------------------------
         // 13. Conditional & Passive Visual Managers
         // ------------------------------------------------------------------
-        this.passiveIconManager = new PassiveIconManager(this.battleSimulationManager, this.idManager, this.skillIconManager);
+        this.passiveIconManager = new PassiveIconManager(
+            this.battleSimulationManager,
+            this.idManager,
+            this.skillIconManager,
+            this.statusEffectManager
+        );
         this.attackManager = new AttackManager(this.eventManager, this.idManager); // AttackManager 인스턴스 생성
 
         // ------------------------------------------------------------------

--- a/js/managers/BattleCalculationManager.js
+++ b/js/managers/BattleCalculationManager.js
@@ -3,7 +3,7 @@ import { DelayEngine } from './DelayEngine.js'; // ✨ DelayEngine 추가
 import { GAME_EVENTS } from '../constants.js';
 
 export class BattleCalculationManager {
-    constructor(eventManager, battleSimulationManager, diceRollManager, delayEngine, conditionalManager, unitStatManager) {
+    constructor(eventManager, battleSimulationManager, diceRollManager, delayEngine, conditionalManager, unitStatManager, statusEffectManager = null) {
         console.log("\ud83d\udcca BattleCalculationManager initialized. Delegating heavy calculations to worker. \ud83d\udcca");
         this.eventManager = eventManager;
         this.battleSimulationManager = battleSimulationManager;
@@ -11,6 +11,7 @@ export class BattleCalculationManager {
         this.delayEngine = delayEngine; // ✨ delayEngine 저장
         this.conditionalManager = conditionalManager; // ✨ 인스턴스 저장
         this.unitStatManager = unitStatManager;
+        this.statusEffectManager = statusEffectManager;
         this.worker = new Worker('./js/workers/battleCalculationWorker.js');
 
         this.worker.onmessage = this._handleWorkerMessage.bind(this);
@@ -77,8 +78,9 @@ export class BattleCalculationManager {
         );
         console.log(`[BattleCalculationManager] Final damage roll from DiceRollManager: ${finalDamageRoll}`);
 
-        // ✨ ConditionalManager에서 수비자의 현재 피해 감소율을 가져옴
-        const damageReduction = this.conditionalManager.getDamageReduction(targetUnitId);
+        const baseReduction = this.conditionalManager.getDamageReduction(targetUnitId);
+        const statusReduction = this._getDamageReductionFromStatusEffects(targetUnitId);
+        const damageReduction = baseReduction + statusReduction;
 
         const payload = {
             attackerStats: attackerUnit.fullUnitData ? attackerUnit.fullUnitData.baseStats : attackerUnit.baseStats,
@@ -96,6 +98,19 @@ export class BattleCalculationManager {
 
         this.worker.postMessage({ type: 'CALCULATE_DAMAGE', payload });
         console.log(`[BattleCalculationManager] Requested damage calculation: ${attackerUnitId} attacks ${targetUnitId}.`);
+    }
+
+    _getDamageReductionFromStatusEffects(unitId) {
+        if (!this.statusEffectManager) return 0;
+        const effects = this.statusEffectManager.getUnitActiveEffects(unitId);
+        let reduction = 0;
+        if (effects) {
+            for (const [id, wrapper] of effects.entries()) {
+                const mod = wrapper.effectData.effect?.statModifiers?.damageReduction;
+                if (mod) reduction += mod;
+            }
+        }
+        return reduction;
     }
 
     terminateWorker() {

--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -54,6 +54,20 @@ export class ClassAIManager {
             };
         }
 
+        const stoneSkinData = WARRIOR_SKILLS.STONE_SKIN;
+        if (
+            this.diceEngine.getRandomFloat() < stoneSkinData.ai.usageChance &&
+            stoneSkinData.ai.condition(unit, null)
+        ) {
+            if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] ${unit.name} decided to use skill: ${stoneSkinData.name}`);
+            return {
+                actionType: 'skill',
+                skillId: stoneSkinData.id,
+                targetId: unit.id,
+                execute: () => this.warriorSkillsAI.stoneSkin(unit, stoneSkinData)
+            };
+        }
+
         const doubleStrikeData = WARRIOR_SKILLS.DOUBLE_STRIKE;
         const targetForDoubleStrike = this.targetingManager.findBestTarget('enemy', 'closest', unit);
         if (targetForDoubleStrike &&

--- a/js/managers/PassiveIconManager.js
+++ b/js/managers/PassiveIconManager.js
@@ -4,11 +4,12 @@ import { GAME_DEBUG_MODE } from '../constants.js';
 import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 
 export class PassiveIconManager {
-    constructor(battleSimulationManager, idManager, skillIconManager) {
+    constructor(battleSimulationManager, idManager, skillIconManager, statusEffectManager) {
         if (GAME_DEBUG_MODE) console.log("\ud83d\udee1\ufe0f PassiveIconManager initialized. Displaying permanent skill icons. \ud83d\udee1\ufe0f");
         this.battleSimulationManager = battleSimulationManager;
         this.idManager = idManager;
         this.skillIconManager = skillIconManager;
+        this.statusEffectManager = statusEffectManager;
         this.iconSizeRatio = 0.2;
         this.iconOffsetYRatio = 0.9;
     }
@@ -19,25 +20,38 @@ export class PassiveIconManager {
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
             if (unit.currentHp <= 0) continue;
 
-            // ✨ 수정된 부분: classData를 조회하는 대신 unit의 skillSlots을 직접 확인
+            const { drawX, drawY } = this.battleSimulationManager.animationManager.getRenderPosition(
+                unit.id,
+                unit.gridX,
+                unit.gridY,
+                effectiveTileSize,
+                gridOffsetX,
+                gridOffsetY
+            );
+
+            const icons = [];
+
             if (unit.skillSlots && unit.skillSlots.includes(WARRIOR_SKILLS.IRON_WILL.id)) {
                 const icon = this.skillIconManager.getSkillIcon(WARRIOR_SKILLS.IRON_WILL.id);
-                if (icon) {
-                    const { drawX, drawY } = this.battleSimulationManager.animationManager.getRenderPosition(
-                        unit.id,
-                        unit.gridX,
-                        unit.gridY,
-                        effectiveTileSize,
-                        gridOffsetX,
-                        gridOffsetY
-                    );
+                if (icon) icons.push(icon);
+            }
 
-                    const baseIconSize = effectiveTileSize * this.iconSizeRatio;
-                    const iconDrawX = drawX + effectiveTileSize - baseIconSize - 5;
-                    const iconDrawY = drawY - (effectiveTileSize * this.iconOffsetYRatio);
-                    ctx.drawImage(icon, iconDrawX, iconDrawY, baseIconSize, baseIconSize);
+            if (this.statusEffectManager) {
+                const effects = this.statusEffectManager.getUnitActiveEffects(unit.id);
+                if (effects) {
+                    for (const [effectId] of effects.entries()) {
+                        const icon = this.skillIconManager.getSkillIcon(effectId);
+                        if (icon && icon.width > 1) icons.push(icon);
+                    }
                 }
             }
+
+            icons.forEach((icon, idx) => {
+                const baseIconSize = effectiveTileSize * this.iconSizeRatio;
+                const iconX = drawX + idx * (baseIconSize + 2);
+                const iconY = drawY - baseIconSize * 0.5;
+                ctx.drawImage(icon, iconX, iconY, baseIconSize, baseIconSize);
+            });
         }
     }
 }

--- a/js/managers/warriorSkillsAI.js
+++ b/js/managers/warriorSkillsAI.js
@@ -11,6 +11,7 @@
 // import { VFXManager } from './VFXManager.js';
 import { GAME_EVENTS, ATTACK_TYPES, GAME_DEBUG_MODE } from '../constants.js'; // ✨ GAME_DEBUG_MODE 임포트
 import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
+import { STATUS_EFFECTS } from '../../data/statusEffects.js';
 
 export class WarriorSkillsAI {
     /**
@@ -165,6 +166,32 @@ export class WarriorSkillsAI {
         } else if (GAME_DEBUG_MODE) {
             console.log(`[WarriorSkillsAI] Target ${targetUnit.name} defeated. Second strike cancelled.`);
         }
+    }
+
+    /**
+     * 스톤 스킨 스킬을 실행합니다. 자신에게 피해 감소 버프를 적용합니다.
+     * @param {object} userUnit - 스킬 시전자
+     * @param {object} skillData - 스킬 데이터
+     */
+    async stoneSkin(userUnit, skillData) {
+        if (!userUnit || userUnit.currentHp <= 0) {
+            if (GAME_DEBUG_MODE) console.warn("[WarriorSkillsAI] Stone Skin failed: Invalid user unit.");
+            return;
+        }
+
+        if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${userUnit.name} uses ${skillData.name}!`);
+
+        this.managers.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
+            unitId: userUnit.id,
+            skillName: skillData.name
+        });
+
+        const effectId = skillData.effect.appliesEffect;
+        if (effectId) {
+            this.managers.workflowManager.triggerStatusEffectApplication(userUnit.id, effectId);
+        }
+
+        await this.managers.delayEngine.waitFor(500);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `STONE_SKIN` status effect data
- create Stone Skin skill for warriors
- implement skill logic in `WarriorSkillsAI`
- calculate damage reduction from active effects in `BattleCalculationManager`
- show active status icons through `PassiveIconManager`
- inject `StatusEffectManager` into icon manager and battle calc manager
- update AI to cast Stone Skin when health is low

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68793fee240083278ca172b283cdd73e