### PR TITLE
Fix DataCloneError in workers

### DIFF
--- a/js/managers/MicrocosmHeroEngine.js
+++ b/js/managers/MicrocosmHeroEngine.js
@@ -40,7 +40,9 @@ export class MicrocosmHeroEngine {
             id: heroData.id,
             name: heroData.name,
             worker: heroAIWorker,
-            state: heroData // 이 영웅만의 고유한 상태 정보
+            // Worker로 전달될 상태는 직렬화 가능한 데이터만 포함해야 합니다.
+            // illustration과 같이 클론 불가능한 객체는 제외한 버전을 사용합니다.
+            state: serializableData
         };
 
         this.heroInstances.set(heroData.id, instance);

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -126,9 +126,18 @@ export class TurnEngine {
             }
 
             // JudgementManager가 AI 결정을 감시할 수 있도록 알림
+            // Web Worker에 전달되는 데이터는 직렬화 가능해야 하므로
+            // 실행 함수를 포함한 원본 액션 객체를 복사한 뒤 함수는 제거한다.
+            let sanitizedAction = null;
+            if (action) {
+                sanitizedAction = { ...action };
+                if (typeof sanitizedAction.execute === 'function') {
+                    delete sanitizedAction.execute;
+                }
+            }
             this.eventManager.emit(GAME_EVENTS.AI_ACTION_DECIDED, {
                 unitId: unit.id,
-                decidedAction: action
+                decidedAction: sanitizedAction
             });
 
             if (action) {


### PR DESCRIPTION
## Summary
- keep MicrocosmHeroEngine worker state cloneable
- sanitize action data before emitting AI_ACTION_DECIDED event

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68794909ad00832780ca7127d4e59622