### PR TITLE
Fix missing skill icons

### DIFF
--- a/data/statusEffects.js
+++ b/data/statusEffects.js
@@ -55,6 +55,7 @@ export const STATUS_EFFECTS = {
         id: 'status_battle_cry',
         name: '전투의 외침',
         type: STATUS_EFFECT_TYPES.BUFF,
+        icon: 'assets/icons/skills/battle_cry.png',
         description: '공격력이 3턴간 10% 증가합니다.',
         duration: 3,
         effect: {
@@ -81,6 +82,7 @@ export const STATUS_EFFECTS = {
         id: 'status_disarmed',
         name: '무장해제',
         type: STATUS_EFFECT_TYPES.DISABLED,
+        icon: 'assets/icons/skills/disarmed.png',
         description: '무기를 잃어 아무런 행동도 할 수 없습니다.',
         duration: -1, // -1은 영구 지속
         effect: {

--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -15,6 +15,7 @@ export const WARRIOR_SKILLS = {
         id: 'skill_warrior_battle_cry',
         name: '전투의 외침',
         type: SKILL_TYPES.BUFF,
+        icon: 'assets/icons/skills/battle_cry.png',
         aiFunction: 'battleCry',
         probability: 30,
         description: '자신의 공격력을 일시적으로 증가시키고 일반 공격을 수행합니다.',
@@ -30,6 +31,7 @@ export const WARRIOR_SKILLS = {
         id: 'skill_warrior_rending_strike',
         name: '찢어발기기',
         type: SKILL_TYPES.DEBUFF,
+        icon: 'assets/icons/skills/rending_strike.png',
         probability: 0, // 평타에 묻어나는 스킬이라 자체 발동 확률은 0
         description: '일반 공격 시 50% 확률로 적에게 출혈 디버프를 부여합니다.',
         requiredUserTags: ['근접'],
@@ -43,6 +45,7 @@ export const WARRIOR_SKILLS = {
         id: 'skill_warrior_retaliate',
         name: '반격',
         type: SKILL_TYPES.REACTION,
+        icon: 'assets/icons/skills/retaliate.png',
         description: '공격을 받을 시 일정 확률로 즉시 80%의 피해로 반격합니다.',
         requiredUserTags: ['방어'],
         effect: {


### PR DESCRIPTION
## Summary
- connect warrior skill data to existing icon files
- show icons for BATTLE_CRY, RENDING_STRIKE, RETALIATE and related status effects

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879a62ece0483278897a715dcc03bd5