### PR TITLE
Add EnemyEngine and flipped sprite support

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -74,6 +74,8 @@ import { PassiveIconManager } from './managers/PassiveIconManager.js';
 import { AttackManager } from './managers/AttackManager.js'; // <-- AttackManager 임포트
 import { BattleFormationManager } from './managers/BattleFormationManager.js';
 import { MonsterSpawnManager } from './managers/MonsterSpawnManager.js';
+import { EnemyEngine } from './managers/EnemyEngine.js';
+import { EnemySpawnManager } from './managers/EnemySpawnManager.js';
 import { UnitStatManager } from './managers/UnitStatManager.js';
 import { StageDataManager } from './managers/StageDataManager.js';
 import { RangeManager } from './managers/RangeManager.js';
@@ -456,6 +458,8 @@ export class GameEngine {
         // 12. Sprite & Action Managers
         // ------------------------------------------------------------------
         this.unitSpriteEngine = new UnitSpriteEngine(this.assetLoaderManager, this.battleSimulationManager);
+        // UnitSpriteEngine 초기화 이후 EnemyEngine을 준비합니다.
+        this.enemyEngine = new EnemyEngine(this.unitSpriteEngine);
         this.unitActionManager = new UnitActionManager(
             this.eventManager,
             this.unitSpriteEngine,
@@ -493,6 +497,8 @@ export class GameEngine {
 
         this.battleFormationManager = new BattleFormationManager(this.battleSimulationManager);
         this.monsterSpawnManager = new MonsterSpawnManager(this.idManager, this.assetLoaderManager, this.battleSimulationManager, this.stageDataManager);
+        // EnemySpawnManager 초기화
+        this.enemySpawnManager = new EnemySpawnManager(this.heroManager, this.enemyEngine, this.battleSimulationManager, this.idManager);
 
         // ------------------------------------------------------------------
         // 13. Conditional & Passive Visual Managers
@@ -709,8 +715,8 @@ export class GameEngine {
     }
 
     async _initBattleGrid() {
-        // 영웅은 이제 자동으로 생성되지 않습니다. 필요 시 recruitNewWarrior를 통해 고용하세요.
-        await this.monsterSpawnManager.spawnMonstersForStage('stage1');
+        // 영웅 데이터를 변환하여 적군 전사를 생성합니다.
+        await this.enemySpawnManager.spawnEnemyWarriors(5);
     }
 
     _update(deltaTime) {
@@ -861,6 +867,8 @@ export class GameEngine {
     getStatusIconManager() { return this.statusIconManager; }
     getBattleFormationManager() { return this.battleFormationManager; }
     getMonsterSpawnManager() { return this.monsterSpawnManager; }
+    getEnemyEngine() { return this.enemyEngine; }
+    getEnemySpawnManager() { return this.enemySpawnManager; }
     getShadowEngine() { return this.shadowEngine; } // ✨ ShadowEngine getter 추가
     getUnitSpriteEngine() { return this.unitSpriteEngine; }
     getUnitActionManager() { return this.unitActionManager; }

--- a/js/managers/EnemyEngine.js
+++ b/js/managers/EnemyEngine.js
@@ -1,0 +1,44 @@
+import { ATTACK_TYPES, GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * HeroEngine을 통해 생성된 영웅 유닛을 적군 버전으로 변환하는 엔진입니다.
+ */
+export class EnemyEngine {
+    /**
+     * @param {UnitSpriteEngine} unitSpriteEngine - 유닛 스프라이트(이미지)를 관리하는 엔진
+     */
+    constructor(unitSpriteEngine) {
+        if (GAME_DEBUG_MODE) console.log("\uD83D\uDC79 EnemyEngine initialized. Ready to turn heroes into foes. \uD83D\uDC79");
+        this.unitSpriteEngine = unitSpriteEngine;
+    }
+
+    /**
+     * 주어진 영웅 데이터를 적군 유닛 데이터로 변환합니다.
+     * @param {object} heroData - HeroManager가 생성한 원본 영웅 데이터
+     * @returns {Promise<object>} 적군으로 변환된 유닛 데이터
+     */
+    async convertHeroToEnemy(heroData) {
+        if (!heroData) {
+            console.error("[EnemyEngine] Cannot convert null hero data.");
+            return null;
+        }
+
+        const enemyData = JSON.parse(JSON.stringify(heroData)); // 깊은 복사
+
+        enemyData.type = ATTACK_TYPES.ENEMY;
+        enemyData.id = `enemy_${heroData.id}`;
+
+        const unitSprites = this.unitSpriteEngine.unitSpriteMap.get(heroData.id);
+        if (unitSprites) {
+            const flippedSpriteStates = {};
+            for (const [state, image] of unitSprites.entries()) {
+                const flippedImage = await this.unitSpriteEngine.getFlippedImage(image);
+                flippedSpriteStates[state] = flippedImage.src;
+            }
+            await this.unitSpriteEngine.registerUnitSprites(enemyData.id, flippedSpriteStates);
+        }
+
+        if (GAME_DEBUG_MODE) console.log(`[EnemyEngine] Converted ${heroData.name} to an enemy unit.`);
+        return enemyData;
+    }
+}

--- a/js/managers/EnemySpawnManager.js
+++ b/js/managers/EnemySpawnManager.js
@@ -1,0 +1,45 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * 전투 시작 시 적군 영웅들을 스폰하는 매니저입니다.
+ */
+export class EnemySpawnManager {
+    constructor(heroManager, enemyEngine, battleSimulationManager, idManager) {
+        if (GAME_DEBUG_MODE) console.log("\uD83D\udd25 EnemySpawnManager initialized. Spawning elite enemies. \uD83D\udd25");
+        this.heroManager = heroManager;
+        this.enemyEngine = enemyEngine;
+        this.battleSimulationManager = battleSimulationManager;
+        this.idManager = idManager;
+    }
+
+    /**
+     * 지정된 수만큼의 적 전사 유닛을 생성하고 배치합니다.
+     * @param {number} count - 스폰할 적 전사의 수
+     */
+    async spawnEnemyWarriors(count) {
+        const heroWarriors = await this.heroManager.createWarriors(count);
+
+        const formation = [
+            { x: 13, y: 4 }, { x: 12, y: 2 }, { x: 12, y: 6 },
+            { x: 14, y: 3 }, { x: 14, y: 5 }
+        ];
+
+        for (let i = 0; i < heroWarriors.length; i++) {
+            const heroData = heroWarriors[i];
+            const enemyData = await this.enemyEngine.convertHeroToEnemy(heroData);
+
+            if (enemyData) {
+                const pos = formation[i] || { x: 13 + i, y: 4 };
+                enemyData.gridX = pos.x;
+                enemyData.gridY = pos.y;
+
+                await this.idManager.addOrUpdateId(enemyData.id, enemyData);
+
+                const spriteMap = this.enemyEngine.unitSpriteEngine.unitSpriteMap.get(enemyData.id);
+                const enemyImage = spriteMap ? spriteMap.get('idle') : null;
+                this.battleSimulationManager.addUnit(enemyData, enemyImage, pos.x, pos.y);
+            }
+        }
+        if (GAME_DEBUG_MODE) console.log(`[EnemySpawnManager] Spawned ${count} enemy warriors.`);
+    }
+}


### PR DESCRIPTION
## Summary
- flip sprites in `UnitSpriteEngine`
- convert heroes into enemies with new `EnemyEngine`
- spawn converted warriors via `EnemySpawnManager`
- integrate new managers in `GameEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879a66a89148327b88a74120b5e400e