### PR TITLE
Fix skill slot checks and update warrior AI

### DIFF
--- a/js/managers/PassiveSkillManager.js
+++ b/js/managers/PassiveSkillManager.js
@@ -32,10 +32,10 @@ export class PassiveSkillManager {
      */
     async _onUnitAttackAttempt({ attackerId, targetId }) {
         const attacker = this.battleSimulationManager.unitsOnGrid.find(u => u.id === attackerId);
-        if (!attacker) return;
+        if (!attacker || !attacker.skillSlots) return; // 공격자나 스킬 슬롯이 없으면 중단
 
-        const classData = await this.idManager.get(attacker.classId);
-        if (!classData || !classData.skills || !classData.skills.includes(WARRIOR_SKILLS.RENDING_STRIKE.id)) {
+        // 💡 변경점: 클래스 데이터(classData)가 아닌 유닛의 실제 스킬 슬롯(skillSlots)을 확인합니다.
+        if (!attacker.skillSlots.includes(WARRIOR_SKILLS.RENDING_STRIKE.id)) {
             return;
         }
 

--- a/js/managers/ReactionSkillManager.js
+++ b/js/managers/ReactionSkillManager.js
@@ -36,10 +36,10 @@ export class ReactionSkillManager {
         if (damage <= 0 || !attackerId) return;
 
         const defender = this.battleSimulationManager.unitsOnGrid.find(u => u.id === defenderId);
-        if (!defender || defender.currentHp <= 0) return;
+        if (!defender || defender.currentHp <= 0 || !defender.skillSlots) return; // 방어자나 스킬 슬롯이 없으면 중단
 
-        const classData = await this.idManager.get(defender.classId);
-        if (!classData || !classData.skills || !classData.skills.includes(WARRIOR_SKILLS.RETALIATE.id)) {
+        // 💡 변경점: 클래스 데이터(classData)가 아닌 유닛의 실제 스킬 슬롯(skillSlots)을 확인합니다.
+        if (!defender.skillSlots.includes(WARRIOR_SKILLS.RETALIATE.id)) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- refine warrior AI skill decisions with explicit checks
- check skill slots directly for Rending Strike and Retaliate triggers

## Testing
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6879b9bbdd18832789b253d178002de2