### PR TITLE
Improve skill slot checks and warrior AI

### DIFF
--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -45,33 +45,85 @@ export class ClassAIManager {
 
     async getWarriorAction(unit, allUnits) {
         const skillToUse = await this.decideSkillToUse(unit);
-
         if (skillToUse) {
             if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] ${unit.name} decided to use skill: ${skillToUse.name}`);
+            return {
+                actionType: 'skill',
+                skillId: skillToUse.id,
+                execute: () => this.executeSkillAI(unit, skillToUse)
+            };
+        }
 
-            let targetUnit = null;
-            // 버프 스킬이나 사거리가 0인 스킬은 자신을 대상으로 합니다.
-            if (skillToUse.type === 'buff' || skillToUse.range === 0) {
-                targetUnit = unit;
-            } else {
-                // 그 외에는 가장 가까운 적을 대상으로 합니다.
-                targetUnit = this.targetingManager.findBestTarget('enemy', 'closest', unit);
+        // 유닛의 스킬 슬롯을 기본으로 판단합니다.
+        if (unit.skillSlots && unit.skillSlots.length > 0) {
+            // 2. 스톤 스킵
+            const stoneSkinData = WARRIOR_SKILLS.STONE_SKIN;
+            if (
+                unit.skillSlots.includes(stoneSkinData.id) &&
+                this.diceEngine.getRandomFloat() < stoneSkinData.ai.usageChance
+            ) {
+                if (stoneSkinData.ai.condition(unit, null)) {
+                    if (GAME_DEBUG_MODE)
+                        console.log(`[ClassAIManager] ${unit.name} decided to use skill: ${stoneSkinData.name}`);
+                    return {
+                        actionType: 'skill',
+                        skillId: stoneSkinData.id,
+                        targetId: unit.id,
+                        execute: () => this.warriorSkillsAI.stoneSkin(unit, stoneSkinData)
+                    };
+                }
             }
 
-            // 스킬 사용에 타겟이 필요한데 찾지 못했다면 기본 행동으로 전환합니다.
-            if (!targetUnit) {
-                if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] ${unit.name} wanted to use ${skillToUse.name}, but no valid target was found. Reverting to basic action.`);
-            } else {
+            // 3. 더블 스트라이크
+            const doubleStrikeData = WARRIOR_SKILLS.DOUBLE_STRIKE;
+            if (
+                unit.skillSlots.includes(doubleStrikeData.id) &&
+                this.diceEngine.getRandomFloat() < doubleStrikeData.ai.usageChance
+            ) {
+                const targetForDoubleStrike = this.targetingManager.findBestTarget(
+                    'enemy',
+                    'closest',
+                    unit
+                );
+                if (
+                    targetForDoubleStrike &&
+                    this.rangeManager.isTargetInRange(unit, targetForDoubleStrike)
+                ) {
+                    if (GAME_DEBUG_MODE)
+                        console.log(`[ClassAIManager] ${unit.name} decided to use skill: ${doubleStrikeData.name}`);
+                    return {
+                        actionType: 'skill',
+                        skillId: doubleStrikeData.id,
+                        targetId: targetForDoubleStrike.id,
+                        execute: () =>
+                            this.warriorSkillsAI.doubleStrike(
+                                unit,
+                                targetForDoubleStrike,
+                                doubleStrikeData
+                            )
+                    };
+                }
+            }
+
+            // 4. 전투의 외치모
+            const battleCryData = WARRIOR_SKILLS.BATTLE_CRY;
+            if (
+                unit.skillSlots.includes(battleCryData.id) &&
+                this.diceEngine.getRandomFloat() < battleCryData.probability / 100
+            ) {
+                if (GAME_DEBUG_MODE)
+                    console.log(`[ClassAIManager] ${unit.name} decided to use skill: ${battleCryData.name}`);
                 return {
                     actionType: 'skill',
-                    skillId: skillToUse.id,
-                    targetId: targetUnit.id,
-                    execute: () => this.executeSkillAI(unit, skillToUse, targetUnit)
+                    skillId: battleCryData.id,
+                    targetId: unit.id,
+                    execute: () => this.warriorSkillsAI.battleCry(unit, battleCryData)
                 };
             }
         }
 
-        if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] No skill was chosen for ${unit.name}, proceeding with basic AI.`);
+        if (GAME_DEBUG_MODE)
+            console.log(`[ClassAIManager] No warrior skill chosen for ${unit.name}, using basic AI.`);
         const defaultMoveRange = unit.baseStats.moveRange || 1;
         const defaultAttackRange = unit.baseStats.attackRange || 1;
         return this.basicAIManager.determineMoveAndTarget(unit, allUnits, defaultMoveRange, defaultAttackRange);
@@ -84,33 +136,23 @@ export class ClassAIManager {
 
         for (const skillId of unit.skillSlots) {
             const skillData = await this.idManager.get(skillId);
-            // 'active' 와 'buff' 타입의 스킬만 턴 행동으로 고려합니다.
             if (!skillData || (skillData.type !== 'active' && skillData.type !== 'buff')) continue;
 
-            // 1. 발동 확률을 먼저 확인합니다.
-            let probability = 0;
-            if (skillData.probability) {
-                probability = skillData.probability / 100;
-            } else if (skillData.ai && typeof skillData.ai.usageChance === 'number') {
-                probability = skillData.ai.usageChance;
-            }
-
-            if (this.diceEngine.getRandomFloat() >= probability) {
-                continue; // 확률 체크 실패
-            }
-
-            // 2. 스킬 사용 조건을 확인합니다.
-            if (skillData.ai && typeof skillData.ai.condition === 'function') {
-                const potentialTarget = skillData.type === 'buff' || skillData.range === 0 ? unit : this.targetingManager.findBestTarget('enemy', 'closest', unit);
-                if (!skillData.ai.condition(unit, potentialTarget)) {
-                    if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] ${unit.name} skipped ${skillData.name}: AI condition not met.`);
-                    continue; // 조건 불일치
+            // 스킬별 추가 사용 조건
+            if (skillId === 'skill_warrior_battle_cry') {
+                const closestEnemy = this.targetingManager.findBestTarget('enemy', 'closest', unit);
+                // 전투의 외치는 적의 범위 안에 적이 있어야 고려
+                if (!closestEnemy || !this.rangeManager.isTargetInRange(unit, closestEnemy)) {
+                    if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] ${unit.name} skipped Battle Cry: No enemy in range.`);
+                    continue;
                 }
             }
 
-            // 모든 검사를 통과하면 이 스킬을 사용하기로 결정합니다.
-            if (GAME_DEBUG_MODE) console.log(`[ClassAIManager Debug] Dice roll success for ${skillData.name} (${probability * 100}%)`);
-            return skillData;
+            const probability = (skillData.probability || 0) / 100;
+            if (this.diceEngine.getRandomFloat() < probability) {
+                if (GAME_DEBUG_MODE) console.log(`[ClassAIManager Debug] Dice roll success for ${skillData.name} (${probability * 100}%)`);
+                return skillData;
+            }
         }
 
         return null;

--- a/js/managers/PassiveSkillManager.js
+++ b/js/managers/PassiveSkillManager.js
@@ -32,11 +32,14 @@ export class PassiveSkillManager {
      */
     async _onUnitAttackAttempt({ attackerId, targetId }) {
         const attacker = this.battleSimulationManager.unitsOnGrid.find(u => u.id === attackerId);
-        if (!attacker) return;
+        if (!attacker || !attacker.skillSlots) return; // 공격자나 스킬 슬롯이 없으면 중단
 
         const classData = await this.idManager.get(attacker.classId);
         if (!classData || !classData.skills || !classData.skills.includes(WARRIOR_SKILLS.RENDING_STRIKE.id)) {
-            return;
+            // 🔎 변경점: 클래스 데이터(classData)가 아닌 유닛의 실제 스킬 슬롯(skillSlots)을 확인합니다.
+            if (!attacker.skillSlots.includes(WARRIOR_SKILLS.RENDING_STRIKE.id)) {
+                return;
+            }
         }
 
         const skillData = WARRIOR_SKILLS.RENDING_STRIKE;

--- a/js/managers/ReactionSkillManager.js
+++ b/js/managers/ReactionSkillManager.js
@@ -36,11 +36,14 @@ export class ReactionSkillManager {
         if (damage <= 0 || !attackerId) return;
 
         const defender = this.battleSimulationManager.unitsOnGrid.find(u => u.id === defenderId);
-        if (!defender || defender.currentHp <= 0) return;
+        if (!defender || defender.currentHp <= 0 || !defender.skillSlots) return; // 방어자나 스킬 슬롯이 없으면 중단
 
         const classData = await this.idManager.get(defender.classId);
         if (!classData || !classData.skills || !classData.skills.includes(WARRIOR_SKILLS.RETALIATE.id)) {
-            return;
+            // 🔎 변경점: 클래스 데이터(classData)가 아닌 유닛의 실제 스킬 슬롯(skillSlots)을 확인합니다.
+            if (!defender.skillSlots.includes(WARRIOR_SKILLS.RETALIATE.id)) {
+                return;
+            }
         }
 
         const skillData = WARRIOR_SKILLS.RETALIATE;


### PR DESCRIPTION
## Summary
- adjust warrior AI to use skill slots for Stone Skin, Double Strike, and Battle Cry
- check unit skill slots in PassiveSkillManager
- check unit skill slots in ReactionSkillManager

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6879bb1424208327b5aed434bea30e29