### PR TITLE
Fix warrior skill AI

### DIFF
--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -17,7 +17,6 @@ export const WARRIOR_SKILLS = {
         type: SKILL_TYPES.BUFF,
         icon: 'assets/icons/skills/battle_cry.png',
         aiFunction: 'battleCry',
-        probability: 30,
         description: '자신의 공격력을 일시적으로 증가시키고 일반 공격을 수행합니다.',
         requiredUserTags: ['전사_클래스'],
         effect: {
@@ -70,7 +69,6 @@ export const WARRIOR_SKILLS = {
             // 이 스킬로 발생한 두 번의 공격은 평타 판정을 받습니다.
         },
         ai: {
-            usageChance: 0.4,
             condition: (user, target) => target && user.getDistanceTo && user.getDistanceTo(target) <= 1
         }
     },
@@ -88,10 +86,7 @@ export const WARRIOR_SKILLS = {
             tags: ['방어', '버프'],
             appliesEffect: 'status_stone_skin'
         },
-        ai: {
-            usageChance: 0.3,
-            condition: (user, target) => user.currentHp / user.baseStats.hp <= 0.5
-        }
+        ai: {}
     },
     // 패시브 스킬 (상시 발동 예시)
     IRON_WILL: {

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -142,7 +142,11 @@ export class TurnEngine {
 
             if (action) {
                 this.timingEngine.addTimedAction(async () => {
-                    if (action.actionType === 'move' || action.actionType === 'moveAndAttack') {
+                    if (
+                        action.actionType === 'move' ||
+                        action.actionType === 'moveAndAttack' ||
+                        action.actionType === 'moveAndSkill'
+                    ) {
                         const startGridX = unit.gridX;
                         const startGridY = unit.gridY;
                         if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Unit ${unit.name} attempts to move from (${startGridX},${startGridY}) to (${action.moveTargetX}, ${action.moveTargetY}).`);
@@ -178,7 +182,7 @@ export class TurnEngine {
                                 if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Target ${action.targetId} is no longer valid or out of range.`);
                             }
                         }
-                    } else if (action.actionType === 'skill') {
+                    } else if (action.actionType === 'skill' || action.actionType === 'moveAndSkill') {
                         if (GAME_DEBUG_MODE) console.log(`[TurnEngine] Unit ${unit.name} attempts to use skill.`);
                         if (typeof action.execute === 'function') {
                             await action.execute();


### PR DESCRIPTION
## Summary
- remove HP condition from Stone Skin and drop hard-coded usage chances
- select skills by slot order (40/30/20) in `ClassAIManager`
- allow Double Strike to move into range using new `moveAndSkill` action
- extend `TurnEngine` to process `moveAndSkill`

## Testing
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 5`
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879bdc06cf48327839f7237bf7be668