### PR TITLE
Implement SlotMachineManager for skill selection

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -81,6 +81,7 @@ import { StageDataManager } from './managers/StageDataManager.js';
 import { RangeManager } from './managers/RangeManager.js';
 import { MonsterEngine } from './managers/MonsterEngine.js';
 import { MonsterAI } from './managers/MonsterAI.js';
+import { SlotMachineManager } from './managers/SlotMachineManager.js';
 
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';
@@ -425,18 +426,18 @@ export class GameEngine {
         };
         this.warriorSkillsAI = new WarriorSkillsAI(commonManagersForSkills);
 
+        // 🎰 슬롯 머신 매니저 초기화
+        this.slotMachineManager = new SlotMachineManager(this.idManager, this.diceEngine);
+
         // ClassAIManager에 추가 매니저 전달
         this.classAIManager = new ClassAIManager(
             this.idManager,
             this.battleSimulationManager,
-            this.measureManager,
             this.basicAIManager,
             this.warriorSkillsAI,
-            this.diceEngine,
             this.targetingManager,
-            this.diceBotEngine,
             this.monsterAI,
-            this.rangeManager // ✨ RangeManager 주입
+            this.slotMachineManager
         );
 
         // ✨ TurnEngine에 새로운 의존성 전달
@@ -882,5 +883,6 @@ export class GameEngine {
     getRangeManager() { return this.rangeManager; }
     getMonsterEngine() { return this.monsterEngine; }
     getMonsterAI() { return this.monsterAI; }
+    getSlotMachineManager() { return this.slotMachineManager; }
     getSoundEngine() { return this.soundEngine; }
 }

--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -1,149 +1,63 @@
-// js/managers/ClassAIManager.js
-
 import { GAME_DEBUG_MODE, ATTACK_TYPES } from '../constants.js';
-import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 
 export class ClassAIManager {
-    constructor(idManager, battleSimulationManager, measureManager, basicAIManager, warriorSkillsAI, diceEngine, targetingManager, diceBotEngine, monsterAI, rangeManager) {
-        console.log("\u269C\uFE0F ClassAIManager initialized. Ready to define class-based AI. \u269C\uFE0F");
+    constructor(idManager, battleSimulationManager, basicAIManager, warriorSkillsAI, targetingManager, monsterAI, slotMachineManager) {
+        console.log("\u2694\uFE0F ClassAIManager initialized. Ready to command units based on class.");
         this.idManager = idManager;
         this.battleSimulationManager = battleSimulationManager;
-        this.measureManager = measureManager;
         this.basicAIManager = basicAIManager;
         this.warriorSkillsAI = warriorSkillsAI;
-        this.diceEngine = diceEngine;
         this.targetingManager = targetingManager;
-        this.diceBotEngine = diceBotEngine;
         this.monsterAI = monsterAI;
-        this.rangeManager = rangeManager; // RangeManager 인스턴스 저장
-    }
-
-    _chooseSkillByOrder(unit) {
-        if (!unit.skillSlots || unit.skillSlots.length === 0) return null;
-        const roll = this.diceEngine.getRandomFloat();
-        if (roll < 0.4) return unit.skillSlots[0];
-        if (roll < 0.7) return unit.skillSlots[1];
-        if (roll < 0.9) return unit.skillSlots[2];
-        return null;
+        this.slotMachineManager = slotMachineManager; // 슬롯 머신 매니저 저장
     }
 
     async getBasicClassAction(unit, allUnits) {
+        // 적 유닛은 몬스터 AI를 사용
         if (unit.type === ATTACK_TYPES.ENEMY) {
             return this.monsterAI.getMeleeAIAction(unit, allUnits);
         }
 
-        if (unit.classId === 'class_warrior') {
-            return this.getWarriorAction(unit, allUnits);
-        }
+        // \uD83C\uDFB0 슬롯 머신을 돌려 스킬을 결정합니다!
+        const skillToUse = await this.slotMachineManager.spin(unit);
 
-        const skillToUse = await this.decideSkillToUse(unit);
+        // 슬롯 머신에서 스킬이 당첨되었다면,
         if (skillToUse) {
-            if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] ${unit.name} decided to use skill: ${skillToUse.name}`);
-            return {
-                actionType: 'skill',
-                skillId: skillToUse.id,
-                execute: () => this.executeSkillAI(unit, skillToUse)
-            };
+            let targetUnit = null;
+            // 버프 스킬이나 사거리가 0인 스킬은 자신을 대상으로 합니다.
+            if (skillToUse.type === 'buff' || skillToUse.range === 0) {
+                targetUnit = unit;
+            } else { // 그 외에는 가장 가까운 적을 대상으로 합니다.
+                targetUnit = this.targetingManager.findBestTarget('enemy', 'closest', unit);
+            }
+
+            // 스킬 사용에 타겟이 필요했는데 못 찾은 경우만 제외
+            if (targetUnit) {
+                return {
+                    actionType: 'skill',
+                    skillId: skillToUse.id,
+                    targetId: targetUnit.id,
+                    execute: () => this.executeSkillAI(unit, skillToUse, targetUnit)
+                };
+            }
         }
 
+        // 스킬이 당첨되지 않았거나, 타겟을 못 찾았다면 기본 행동(이동 및 공격)을 합니다.
         if (GAME_DEBUG_MODE) console.log(`[ClassAIManager] No skill was chosen for ${unit.name}, proceeding with basic AI.`);
         const defaultMoveRange = unit.baseStats.moveRange || 1;
         const defaultAttackRange = unit.baseStats.attackRange || 1;
         return this.basicAIManager.determineMoveAndTarget(unit, allUnits, defaultMoveRange, defaultAttackRange);
     }
-
-    async getWarriorAction(unit, allUnits) {
-        const skillData = await this.decideSkillToUse(unit);
-        if (skillData) {
-            if (skillData.id === WARRIOR_SKILLS.STONE_SKIN.id) {
-                return {
-                    actionType: 'skill',
-                    skillId: skillData.id,
-                    targetId: unit.id,
-                    execute: () => this.warriorSkillsAI.stoneSkin(unit, skillData)
-                };
-            }
-
-            if (skillData.id === WARRIOR_SKILLS.DOUBLE_STRIKE.id) {
-                const target = this.targetingManager.findBestTarget('enemy', 'closest', unit);
-                if (target) {
-                    if (this.rangeManager.isTargetInRange(unit, target)) {
-                        return {
-                            actionType: 'skill',
-                            skillId: skillData.id,
-                            targetId: target.id,
-                            execute: () => this.warriorSkillsAI.doubleStrike(unit, target, skillData)
-                        };
-                    }
-
-                    const posMgr = this.basicAIManager.positionManager;
-                    const moveRange = unit.baseStats.moveRange || 1;
-                    const positions = posMgr.getAttackablePositions(target, 1);
-                    let bestPath = null;
-                    for (const pos of positions) {
-                        const path = posMgr.findPath({ x: unit.gridX, y: unit.gridY }, pos);
-                        if (path && path.length - 1 <= moveRange) {
-                            if (!bestPath || path.length < bestPath.length) {
-                                bestPath = path;
-                            }
-                        }
-                    }
-                    if (bestPath) {
-                        const dest = bestPath[bestPath.length - 1];
-                        return {
-                            actionType: 'moveAndSkill',
-                            targetId: target.id,
-                            moveTargetX: dest.x,
-                            moveTargetY: dest.y,
-                            execute: () => this.warriorSkillsAI.doubleStrike(unit, target, skillData)
-                        };
-                    }
-                }
-            }
-
-            if (skillData.id === WARRIOR_SKILLS.BATTLE_CRY.id) {
-                return {
-                    actionType: 'skill',
-                    skillId: skillData.id,
-                    targetId: unit.id,
-                    execute: () => this.warriorSkillsAI.battleCry(unit, skillData)
-                };
-            }
-        }
-
-        if (GAME_DEBUG_MODE)
-            console.log(`[ClassAIManager] No warrior skill chosen for ${unit.name}, using basic AI.`);
-        const defaultMoveRange = unit.baseStats.moveRange || 1;
-        const defaultAttackRange = unit.baseStats.attackRange || 1;
-        return this.basicAIManager.determineMoveAndTarget(unit, allUnits, defaultMoveRange, defaultAttackRange);
-    }
-
-    async decideSkillToUse(unit) {
-        const chosenId = this._chooseSkillByOrder(unit);
-        if (!chosenId) return null;
-        const skillData = await this.idManager.get(chosenId);
-        if (!skillData || skillData.type === 'passive') return null;
-
-        if (chosenId === WARRIOR_SKILLS.BATTLE_CRY.id) {
-            const enemy = this.targetingManager.findBestTarget('enemy', 'closest', unit);
-            if (!enemy || !this.rangeManager.isTargetInRange(unit, enemy)) return null;
-        }
-
-        return skillData;
-    }
-
+    
     async executeSkillAI(userUnit, skillData, targetUnit) {
-        // 스킬 데이터에 정의된 aiFunction 이름을 가져옵니다.
         if (!skillData.aiFunction) {
             if (GAME_DEBUG_MODE) console.warn(`[ClassAIManager] Skill '${skillData.name}' has no 'aiFunction' property to execute.`);
             return;
         }
 
-        // warriorSkillsAI 객체에서 해당 이름의 함수를 찾습니다.
         const aiFunction = this.warriorSkillsAI[skillData.aiFunction];
 
         if (typeof aiFunction === 'function') {
-            // 찾은 함수를 실행합니다.
             await aiFunction.call(this.warriorSkillsAI, userUnit, targetUnit, skillData);
         } else {
             if (GAME_DEBUG_MODE) console.warn(`[ClassAIManager] AI function '${skillData.aiFunction}' not found in WarriorSkillsAI for skill '${skillData.name}'.`);

--- a/js/managers/SlotMachineManager.js
+++ b/js/managers/SlotMachineManager.js
@@ -1,0 +1,48 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * 유닛의 스킬 슬롯을 순서대로 돌면서 고정된 확률로 스킬 사용을 결정하는 매니저입니다.
+ * 1번 슬롯: 40%, 2번 슬롯: 30%, 3번 슬롯: 20%
+ */
+export class SlotMachineManager {
+    constructor(idManager, diceEngine) {
+        if (GAME_DEBUG_MODE) console.log("\uD83C\uDFB0 SlotMachineManager initialized. Fixed odds, ready to spin!");
+        this.idManager = idManager;
+        this.diceEngine = diceEngine;
+        // 스킬 슬롯 순서별 고정 확률
+        this.probabilities = [0.4, 0.3, 0.2]; 
+    }
+
+    /**
+     * 슬롯 머신을 돌려 사용할 스킬을 결정합니다.
+     * @param {object} unit - 스킬을 사용할 유닛
+     * @returns {Promise<object | null>} - 발동에 성공한 스킬 데이터 또는 null
+     */
+    async spin(unit) {
+        if (!unit.skillSlots || unit.skillSlots.length === 0) {
+            return null;
+        }
+
+        // 1번, 2번, 3번 스킬 슬롯을 순서대로 확인 (최대 3개까지만)
+        for (let i = 0; i < unit.skillSlots.length; i++) {
+            const skillId = unit.skillSlots[i];
+            const skillData = await this.idManager.get(skillId);
+            
+            // 액티브 또는 버프 스킬이 아니면 이 매니저에서 처리하지 않습니다.
+            if (!skillData || (skillData.type !== 'active' && skillData.type !== 'buff')) {
+                continue;
+            }
+
+            const chance = this.probabilities[i]; // 1번 슬롯은 0.4, 2번은 0.3...
+            if (this.diceEngine.getRandomFloat() < chance) {
+                // 확률 성공!
+                if (GAME_DEBUG_MODE) console.log(`[SlotMachine] \uD83C\uDFB0 Success! Slot ${i + 1} skill '${skillData.name}' triggered (Chance: ${chance * 100}%).`);
+                return skillData; // 성공한 스킬을 반환하고 즉시 종료 (순차적 경쟁)
+            }
+        }
+
+        // 모든 스킬의 확률 경쟁에서 실패하면 null을 반환합니다.
+        if (GAME_DEBUG_MODE) console.log(`[SlotMachine] ${unit.name} failed all skill rolls.`);
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `SlotMachineManager` that chooses skills based on slot order with fixed odds
- register the new manager inside `GameEngine`
- simplify `ClassAIManager` to delegate skill choice to the slot machine

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879c18d526883278716dbd4336f4fe2