### PR TITLE
Add managers for skill slot and passive tracking

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -83,6 +83,8 @@ import { MonsterEngine } from './managers/MonsterEngine.js';
 import { MonsterAI } from './managers/MonsterAI.js';
 import { SlotMachineManager } from './managers/SlotMachineManager.js';
 
+import { OneTwoThreeManager } from './managers/OneTwoThreeManager.js';
+import { PassiveIsAlsoASkillManager } from './managers/PassiveIsAlsoASkillManager.js';
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';
 
@@ -437,8 +439,11 @@ export class GameEngine {
             this.warriorSkillsAI,
             this.targetingManager,
             this.monsterAI,
-            this.slotMachineManager
+            this.slotMachineManager,
+            this.eventManager
         );
+        this.oneTwoThreeManager = new OneTwoThreeManager(this.eventManager, this.battleSimulationManager);
+        this.passiveIsAlsoASkillManager = new PassiveIsAlsoASkillManager(this.eventManager, this.battleSimulationManager, this.idManager);
 
         // ✨ TurnEngine에 새로운 의존성 전달
         this.turnEngine = new TurnEngine(
@@ -885,4 +890,6 @@ export class GameEngine {
     getMonsterAI() { return this.monsterAI; }
     getSlotMachineManager() { return this.slotMachineManager; }
     getSoundEngine() { return this.soundEngine; }
+    getOneTwoThreeManager() { return this.oneTwoThreeManager; }
+    getPassiveIsAlsoASkillManager() { return this.passiveIsAlsoASkillManager; }
 }

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,6 +1,5 @@
 export const GAME_EVENTS = {
     UNIT_DEATH: 'unitDeath',
-    SKILL_EXECUTED: 'skillExecuted',
     DISPLAY_SKILL_NAME: 'displaySkillName', // 스킬 이름 표시 요청 이벤트
     BATTLE_START: 'battleStart',
     BATTLE_END: 'battleEnd',
@@ -19,6 +18,10 @@ export const GAME_EVENTS = {
     LOG_MESSAGE: 'logMessage',
     WEAPON_DROPPED: 'weaponDropped',
     UNIT_DISARMED: 'unitDisarmed',
+    UNIT_REMOVED_FROM_GRID: 'unitRemovedFromGrid',
+    SKILL_EXECUTED: 'skillExecuted', // 스킬이 실행됨
+    SKILL_SLOT_ACTIVATED: 'skillSlotActivated', // N번째 스킬 슬롯이 활성화됨
+    PASSIVE_SKILL_MAINTAINED: 'passiveSkillMaintained', // 패시브 스킬이 턴마다 유지됨
     REQUEST_STATUS_EFFECT_APPLICATION: 'requestStatusEffectApplication',
     DRAG_START: 'dragStart',
     DRAG_MOVE: 'dragMove',

--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -1,7 +1,7 @@
-import { GAME_DEBUG_MODE, ATTACK_TYPES } from '../constants.js';
+import { GAME_DEBUG_MODE, GAME_EVENTS, ATTACK_TYPES } from '../constants.js';
 
 export class ClassAIManager {
-    constructor(idManager, battleSimulationManager, basicAIManager, warriorSkillsAI, targetingManager, monsterAI, slotMachineManager) {
+    constructor(idManager, battleSimulationManager, basicAIManager, warriorSkillsAI, targetingManager, monsterAI, slotMachineManager, eventManager) {
         console.log("\u2694\uFE0F ClassAIManager initialized. Ready to command units based on class.");
         this.idManager = idManager;
         this.battleSimulationManager = battleSimulationManager;
@@ -10,6 +10,7 @@ export class ClassAIManager {
         this.targetingManager = targetingManager;
         this.monsterAI = monsterAI;
         this.slotMachineManager = slotMachineManager; // 슬롯 머신 매니저 저장
+        this.eventManager = eventManager;
     }
 
     async getBasicClassAction(unit, allUnits) {
@@ -50,6 +51,7 @@ export class ClassAIManager {
     }
     
     async executeSkillAI(userUnit, skillData, targetUnit) {
+        this.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, { unitId: userUnit.id, skillId: skillData.id });
         if (!skillData.aiFunction) {
             if (GAME_DEBUG_MODE) console.warn(`[ClassAIManager] Skill '${skillData.name}' has no 'aiFunction' property to execute.`);
             return;

--- a/js/managers/OneTwoThreeManager.js
+++ b/js/managers/OneTwoThreeManager.js
@@ -1,0 +1,44 @@
+// js/managers/OneTwoThreeManager.js
+
+import { GAME_DEBUG_MODE, GAME_EVENTS } from '../constants.js';
+
+/**
+ * 유닛이 몇 번째 스킬 슬롯을 활성화했는지 감지하고 이벤트를 발생시키는 매니저입니다.
+ */
+export class OneTwoThreeManager {
+    constructor(eventManager, battleSimulationManager) {
+        if (GAME_DEBUG_MODE) console.log("🥁 OneTwoThreeManager initialized. Ready to feel the rhythm.");
+        this.eventManager = eventManager;
+        this.battleSimulationManager = battleSimulationManager;
+
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        // ClassAIManager가 스킬을 실행하기 직전에 보내는 신호를 구독합니다.
+        this.eventManager.subscribe(GAME_EVENTS.SKILL_EXECUTED, this._onSkillExecuted.bind(this));
+    }
+
+    /**
+     * 스킬이 실행되었을 때 호출됩니다.
+     * @param {object} data - { unitId, skillId }
+     */
+    _onSkillExecuted({ unitId, skillId }) {
+        const unit = this.battleSimulationManager.getUnitById(unitId);
+        if (!unit || !unit.skillSlots) return;
+
+        const slotIndex = unit.skillSlots.indexOf(skillId);
+
+        // 스킬이 유닛의 슬롯 목록에 있는지, 그리고 1, 2, 3번 슬롯 중 하나인지 확인합니다.
+        if (slotIndex !== -1) {
+            if (GAME_DEBUG_MODE) console.log(`[OneTwoThreeManager] Detected: ${unit.name} used Slot ${slotIndex + 1} skill (${skillId}).`);
+            
+            // "N번째 스킬 슬롯이 활성화되었다!" 라고 새로운 이벤트를 외쳐줍니다.
+            this.eventManager.emit(GAME_EVENTS.SKILL_SLOT_ACTIVATED, {
+                unitId: unitId,
+                skillId: skillId,
+                slotIndex: slotIndex // 0-based index (0, 1, 2)
+            });
+        }
+    }
+}

--- a/js/managers/PassiveIsAlsoASkillManager.js
+++ b/js/managers/PassiveIsAlsoASkillManager.js
@@ -1,0 +1,73 @@
+// js/managers/PassiveIsAlsoASkillManager.js
+
+import { GAME_DEBUG_MODE, GAME_EVENTS } from '../constants.js';
+
+/**
+ * 유닛의 패시브 스킬이 몇 턴 동안 유지되고 있는지 추적하는 매니저입니다.
+ */
+export class PassiveIsAlsoASkillManager {
+    constructor(eventManager, battleSimulationManager, idManager) {
+        if (GAME_DEBUG_MODE) console.log("\ud83e\udd08 PassiveIsAlsoASkillManager initialized. Patience is a virtue.");
+        this.eventManager = eventManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.idManager = idManager;
+
+        // { unitId: { skillId: turnCount } } 형태로 데이터를 저장합니다.
+        this.passiveCounters = {};
+
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        // 각 유닛의 턴이 시작될 때마다 카운트를 세기 위해 구독합니다.
+        this.eventManager.subscribe(GAME_EVENTS.TURN_START, this._onTurnStart.bind(this));
+        // 유닛이 전투에서 제거되면 카운터도 정리합니다.
+        this.eventManager.subscribe(GAME_EVENTS.UNIT_REMOVED_FROM_GRID, this._onUnitRemoved.bind(this));
+    }
+
+    /**
+     * 유닛의 턴이 시작될 때 호출됩니다.
+     * @param {object} data - { unitId }
+     */
+    async _onTurnStart({ unitId }) {
+        const unit = this.battleSimulationManager.getUnitById(unitId);
+        if (!unit) return;
+
+        if (!this.passiveCounters[unitId]) {
+            this.passiveCounters[unitId] = {};
+        }
+
+        // 현재 유닛에게 적용된 모든 상태 효과를 확인합니다.
+        for (const effect of unit.statusEffects) {
+            const sourceSkill = await this.idManager.get(effect.sourceSkillId);
+            
+            // 이 효과의 근원 스킬이 'passive' 타입인지 확인합니다.
+            if (sourceSkill && sourceSkill.type === 'passive') {
+                const skillId = sourceSkill.id;
+
+                // 카운터를 1 증가시킵니다. (없었으면 1로 시작)
+                const currentCount = (this.passiveCounters[unitId][skillId] || 0) + 1;
+                this.passiveCounters[unitId][skillId] = currentCount;
+
+                if (GAME_DEBUG_MODE) console.log(`[PassiveManager] ${unit.name}'s passive '${skillId}' is now at ${currentCount} turn(s).`);
+
+                // "패시브 스킬이 N턴째 유지 중이다!" 라고 이벤트를 외쳐줍니다.
+                this.eventManager.emit(GAME_EVENTS.PASSIVE_SKILL_MAINTAINED, {
+                    unitId: unitId,
+                    skillId: skillId,
+                    maintainedTurns: currentCount
+                });
+            }
+        }
+    }
+    
+    /**
+     * 유닛이 전투에서 제거될 때 카운터를 정리합니다.
+     */
+    _onUnitRemoved({ unitId }) {
+        if (this.passiveCounters[unitId]) {
+            delete this.passiveCounters[unitId];
+            if (GAME_DEBUG_MODE) console.log(`[PassiveManager] Cleared passive counters for removed unit ${unitId}.`);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `OneTwoThreeManager` to detect which skill slot was used
- add `PassiveIsAlsoASkillManager` to track passive skill durations
- extend `GAME_EVENTS` with new events for these managers
- register the new managers in `GameEngine`
- allow `ClassAIManager` to emit `SKILL_EXECUTED`

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879c89f644c8327ba1433d7add0cee6