### PR TITLE
Allow warrior class to use any skill

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -19,10 +19,8 @@ export const CLASSES = {
         name: '전사',
         role: CLASS_ROLES.MELEE_DPS,
         description: '강력한 근접 공격과 방어력을 겸비한 병종.',
-        skills: [
-            WARRIOR_SKILLS.BATTLE_CRY.id,
-            WARRIOR_SKILLS.IRON_WILL.id
-        ],
+        // 개별 영웅 생성 시 WarriorSkills 전체 목록에서 무작위로 부여됩니다.
+        skills: [],
         moveRange: 3, // 전사의 이동 거리
         tags: ['근접', '방어', '용병_클래스'] // ✨ 태그 추가
     },
@@ -32,10 +30,8 @@ export const CLASSES = {
         name: '용맹 기사',
         role: CLASS_ROLES.TANK,
         description: '전사의 전투 경험을 극대화한 고급 병종으로, 방어와 리더십이 뛰어납니다.',
-        skills: [
-            WARRIOR_SKILLS.BATTLE_CRY.id,
-            WARRIOR_SKILLS.IRON_WILL.id
-        ],
+        // 상위 클래스 또한 스킬은 무작위로 결정됩니다.
+        skills: [],
         moveRange: 3,
         tags: ['근접', '방어', '용병_클래스', '고급']
     },

--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -18,7 +18,6 @@ export const WARRIOR_SKILLS = {
         icon: 'assets/icons/skills/battle_cry.png',
         aiFunction: 'battleCry',
         description: '자신의 공격력을 일시적으로 증가시키고 일반 공격을 수행합니다.',
-        requiredUserTags: ['전사_클래스'],
         effect: {
             dice: { num: 1, sides: 6 },
             statusEffectId: 'status_battle_cry', // 적용할 상태이상 ID
@@ -33,7 +32,6 @@ export const WARRIOR_SKILLS = {
         icon: 'assets/icons/skills/rending_strike.png',
         probability: 0, // 평타에 묻어나는 스킬이라 자체 발동 확률은 0
         description: '일반 공격 시 50% 확률로 적에게 출혈 디버프를 부여합니다.',
-        requiredUserTags: ['근접'],
         effect: {
             statusEffectId: 'status_bleed', // 적용할 출혈 상태이상 ID
             applyChance: 0.5 // 기본 적용 확률 50%
@@ -46,7 +44,6 @@ export const WARRIOR_SKILLS = {
         type: SKILL_TYPES.REACTION,
         icon: 'assets/icons/skills/retaliate.png',
         description: '공격을 받을 시 일정 확률로 즉시 80%의 피해로 반격합니다.',
-        requiredUserTags: ['방어'],
         effect: {
             probability: 0.4, // 기본 발동 확률 40% (슬롯에 따라 조정될 수 있음)
             damageModifier: 0.8, // 반격 시 피해량 80%
@@ -95,7 +92,6 @@ export const WARRIOR_SKILLS = {
         type: SKILL_TYPES.PASSIVE,
         icon: 'assets/icons/skills/iron_will.png',
         description: '잃은 체력에 비례하여 받는 피해량이 최대 30%까지 감소합니다.',
-        requiredUserTags: ['방어'],
         effect: {
             // 이 효과는 ConditionalManager가 실시간으로 계산하므로
             // 여기에는 패시브 식별용 정보만 남겨둡니다.

--- a/js/managers/ConditionalManager.js
+++ b/js/managers/ConditionalManager.js
@@ -26,7 +26,9 @@ export class ConditionalManager {
             }
 
             const classData = await this.idManager.get(unit.classId);
-            if (classData && classData.skills && classData.skills.includes(WARRIOR_SKILLS.IRON_WILL.id)) {
+            const hasIronWill = (unit.skillSlots && unit.skillSlots.includes(WARRIOR_SKILLS.IRON_WILL.id)) ||
+                (classData && classData.skills && classData.skills.includes(WARRIOR_SKILLS.IRON_WILL.id));
+            if (hasIronWill) {
                 const lostHpRatio = 1 - (unit.currentHp / unit.baseStats.hp);
                 const damageReduction = WARRIOR_SKILLS.IRON_WILL.effect.maxReduction * lostHpRatio;
                 this.damageReductionMap.set(unit.id, damageReduction);

--- a/js/managers/HeroEngine.js
+++ b/js/managers/HeroEngine.js
@@ -1,5 +1,6 @@
 // js/managers/HeroEngine.js
 import { CLASSES } from '../../data/class.js';
+import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 
 export class HeroEngine {
     /**
@@ -108,12 +109,18 @@ export class HeroEngine {
         baseStats.moveRange = classData?.moveRange || 1;
         baseStats.attackRange = classData?.attackRange || 1;
 
-        // 3. 랜덤한 세 가지 스킬 부여 (임시 스킬 ID 사용)
-        const skills = [
-            `skill_${this.diceEngine.getRandomInt(1, 3)}`, // 첫 번째 스킬
-            `skill_${this.diceEngine.getRandomInt(4, 6)}`, // 두 번째 스킬
-            `skill_passive_${this.diceEngine.getRandomInt(1, 2)}` // 세 번째 스킬 (패시브)
-        ];
+        // 3. 랜덤한 세 가지 스킬 부여
+        let skills;
+        if (classId === CLASSES.WARRIOR.id) {
+            const allSkillIds = Object.values(WARRIOR_SKILLS).map(s => s.id);
+            skills = this.diceBotEngine.pickUniqueItems(allSkillIds, 3);
+        } else {
+            skills = [
+                `skill_${this.diceEngine.getRandomInt(1, 3)}`,
+                `skill_${this.diceEngine.getRandomInt(4, 6)}`,
+                `skill_passive_${this.diceEngine.getRandomInt(1, 2)}`
+            ];
+        }
 
         // 4. 랜덤한 특성 부여 (임시 특성 ID 사용)
         const traits = [`trait_${this.diceEngine.getRandomInt(1, 3)}`];
@@ -143,7 +150,7 @@ export class HeroEngine {
             rarity: options.rarity || 'common',
             illustration: illustrationImage,
             baseStats: baseStats,
-            skills: skills,
+            skillSlots: skills,
             traits: traits,
             synergies: synergies, // ✨ 영웅 시너지 추가
             equippedItems: equippedItems,


### PR DESCRIPTION
## Summary
- remove `requiredUserTags` from warrior skills
- let warrior classes have no fixed skill list
- check per-unit skill list before applying Iron Will
- give generated warriors random skills and expose them via `skillSlots`

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879cc94175883279e97f10762fe94ed