### PR TITLE
Fix skill icon loading and add tests

### DIFF
--- a/js/managers/SkillIconManager.js
+++ b/js/managers/SkillIconManager.js
@@ -37,16 +37,15 @@ export class SkillIconManager {
      */
     async _loadAllIcons() {
         if (GAME_DEBUG_MODE) console.log("[SkillIconManager] Loading all defined skill and status icons...");
-        const allSkillsAndEffects = {
-            ...WARRIOR_SKILLS,
-            ...STATUS_EFFECTS
+        const allSkillsAndEffects = [
+            ...Object.values(WARRIOR_SKILLS),
+            ...Object.values(STATUS_EFFECTS)
             // 나중에 다른 직업 스킬도 여기에 추가: ...MAGE_SKILLS
-        };
+        ];
 
         const loadPromises = [];
 
-        for (const key in allSkillsAndEffects) {
-            const item = allSkillsAndEffects[key];
+        for (const item of allSkillsAndEffects) {
             if (item.icon && !this.skillIcons.has(item.id)) {
                 const url = item.icon;
                 const assetId = `icon_${item.id}`;

--- a/test/SkillIconManager.test.js
+++ b/test/SkillIconManager.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SkillIconManager } from '../js/managers/SkillIconManager.js';
+
+class ImageMock {
+  constructor() { this._src = ''; }
+  set src(value) { this._src = value; }
+  get src() { return this._src; }
+}
+
+test('SkillIconManager returns correct warrior skill icons', async () => {
+  global.Image = ImageMock;
+  const mockLoader = { loadImage: async (id, url) => ({ src: url }) };
+  const sim = new SkillIconManager(mockLoader, {});
+  await sim._loadAllIcons();
+  const battleCry = sim.getSkillIcon('skill_warrior_battle_cry');
+  const stoneSkin = sim.getSkillIcon('skill_warrior_stone_skin');
+  assert.ok(battleCry.src.endsWith('battle_cry.png'));
+  assert.ok(stoneSkin.src.endsWith('stone-skin-icon.png'));
+});


### PR DESCRIPTION
## Summary
- ensure skill and status icons don't clobber each other when loading
- add Node unit test for SkillIconManager icon paths

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879d60bdb24832783fa71fccf4cd675