### PR TITLE
Implement shield-break and enemy skill display

### DIFF
--- a/data/statusEffects.js
+++ b/data/statusEffects.js
@@ -90,5 +90,19 @@ export const STATUS_EFFECTS = {
             canAttack: false,
             canMove: false
         }
+    },
+
+    STATUS_SHIELD_BREAK: {
+        id: 'status_shield_break',
+        name: '쉴드 브레이크',
+        description: '받는 모든 피해가 10% 증가합니다.',
+        icon: 'assets/icons/status_effects/shield-break.png',
+        duration: 3,
+        type: STATUS_EFFECT_TYPES.DEBUFF,
+        effect: {
+            statModifiers: {
+                damageTakenMultiplier: 1.10
+            }
+        }
     }
 };

--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -31,10 +31,9 @@ export const WARRIOR_SKILLS = {
         type: SKILL_TYPES.DEBUFF,
         icon: 'assets/icons/skills/rending_strike.png',
         probability: 0, // 평타에 묻어나는 스킬이라 자체 발동 확률은 0
-        description: '일반 공격 시 50% 확률로 적에게 출혈 디버프를 부여합니다.',
+        description: '일반 공격 시 일정 확률로 적에게 출혈 디버프를 부여합니다.',
         effect: {
-            statusEffectId: 'status_bleed', // 적용할 출혈 상태이상 ID
-            applyChance: 0.5 // 기본 적용 확률 50%
+            statusEffectId: 'status_bleed'
         }
     },
     // 리액션 스킬 (공격 받을 시 발동 예시)
@@ -45,9 +44,19 @@ export const WARRIOR_SKILLS = {
         icon: 'assets/icons/skills/retaliate.png',
         description: '공격을 받을 시 일정 확률로 즉시 80%의 피해로 반격합니다.',
         effect: {
-            probability: 0.4, // 기본 발동 확률 40% (슬롯에 따라 조정될 수 있음)
             damageModifier: 0.8, // 반격 시 피해량 80%
             tags: ['일반공격'] // 이 공격이 평타 판정임을 명시
+        }
+    },
+
+    SHIELD_BREAK: {
+        id: 'skill_warrior_shield_break',
+        name: '쉴드 브레이크',
+        description: '일반 공격 시 대상이 3턴간 받는 피해를 10% 증가시킵니다.',
+        type: SKILL_TYPES.DEBUFF,
+        icon: 'assets/icons/skills/shield-break.png',
+        effect: {
+            statusEffectId: 'status_shield_break'
         }
     },
     // 액티브 스킬: 빠르게 두 번 공격

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -723,6 +723,7 @@ export class GameEngine {
         // ✨ 좀비 무기 이미지 로드
         await this.assetLoaderManager.loadImage('sprite_zombie_weapon_default', 'assets/images/zombie-weapon.png');
         await this.assetLoaderManager.loadImage('bleed', 'assets/icons/status_effects/bleed.png');
+        await this.assetLoaderManager.loadImage('icon_status_shield_break', 'assets/icons/status_effects/shield-break.png');
 
         await this._initBattleGrid();
     }

--- a/js/managers/DetailInfoManager.js
+++ b/js/managers/DetailInfoManager.js
@@ -242,6 +242,8 @@ export class DetailInfoManager {
         // ✨ 수정된 부분: heroDetails.skillSlots을 먼저 확인하도록 변경
         if (heroDetails && heroDetails.skillSlots && heroDetails.skillSlots.length > 0) {
             skillsToList = heroDetails.skillSlots;
+        } else if (this.hoveredUnit.skillSlots && this.hoveredUnit.skillSlots.length > 0) {
+            skillsToList = this.hoveredUnit.skillSlots;
         } else if (classData && classData.skills && classData.skills.length > 0) {
             skillsToList = classData.skills;
         }

--- a/js/managers/ReactionSkillManager.js
+++ b/js/managers/ReactionSkillManager.js
@@ -38,17 +38,16 @@ export class ReactionSkillManager {
         const defender = this.battleSimulationManager.unitsOnGrid.find(u => u.id === defenderId);
         if (!defender || defender.currentHp <= 0 || !defender.skillSlots) return; // 방어자나 스킬 슬롯이 없으면 중단
 
-        const classData = await this.idManager.get(defender.classId);
-        if (!classData || !classData.skills || !classData.skills.includes(WARRIOR_SKILLS.RETALIATE.id)) {
-            // 🔎 변경점: 클래스 데이터(classData)가 아닌 유닛의 실제 스킬 슬롯(skillSlots)을 확인합니다.
-            if (!defender.skillSlots.includes(WARRIOR_SKILLS.RETALIATE.id)) {
-                return;
-            }
+        if (!defender.skillSlots.includes(WARRIOR_SKILLS.RETALIATE.id)) {
+            return;
         }
 
         const skillData = WARRIOR_SKILLS.RETALIATE;
+        const slotProb = [0.4, 0.3, 0.2];
+        const slotIndex = defender.skillSlots.indexOf(skillData.id);
+        const chance = slotProb[slotIndex] || 0;
 
-        if (this.diceEngine.getRandomFloat() < skillData.effect.probability) {
+        if (this.diceEngine.getRandomFloat() < chance) {
             if (GAME_DEBUG_MODE) console.log(`[ReactionSkillManager] ${defender.name}'s Retaliate triggered against ${attackerId}!`);
 
             // 스킬 이름 표시 이벤트 발생

--- a/js/managers/warriorSkillsAI.js
+++ b/js/managers/warriorSkillsAI.js
@@ -105,17 +105,13 @@ export class WarriorSkillsAI {
         }
         if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${userUnit.name} attempts ${skillData.name} on ${targetUnit.name}!`);
 
-        if (skillData.effect.applyChance && this.managers.diceEngine.getRandomFloat() < skillData.effect.applyChance) {
-            this.managers.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
-                unitId: userUnit.id,
-                skillName: skillData.name
-            });
-            this.managers.workflowManager.triggerStatusEffectApplication(targetUnit.id, skillData.effect.statusEffectId);
-            await this.managers.delayEngine.waitFor(100);
-            if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${targetUnit.name} is now bleeding!`);
-        } else {
-            if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${skillData.name} failed to apply to ${targetUnit.name}.`);
-        }
+        this.managers.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
+            unitId: userUnit.id,
+            skillName: skillData.name
+        });
+        this.managers.workflowManager.triggerStatusEffectApplication(targetUnit.id, skillData.effect.statusEffectId);
+        await this.managers.delayEngine.waitFor(100);
+        if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] ${targetUnit.name} is now affected by ${skillData.name}!`);
 
         this.managers.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, {
             skillId: skillData.id,


### PR DESCRIPTION
## Summary
- add `STATUS_SHIELD_BREAK` and update status list
- implement `SHIELD_BREAK` warrior skill
- rework passive and reaction skill managers for slot-based chances
- simplify rending strike AI logic
- load shield-break icon in game engine
- show enemy skillSlots in detail info tooltip

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879dc205f588327858e9b1695445858