### PR TITLE
Implement unit lookup and worker sanitization

### DIFF
--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -110,6 +110,15 @@ export class BattleSimulationManager {
     }
 
     /**
+     * ID로 유닛을 찾습니다.
+     * @param {string} unitId
+     * @returns {object|undefined}
+     */
+    getUnitById(unitId) {
+        return this.unitsOnGrid.find(unit => unit.id === unitId);
+    }
+
+    /**
      * 유닛 렌더링에 필요한 그리드 관련 파라미터를 반환합니다.
      * 이 값들은 BattleGridManager와 VFXManager에서도 사용됩니다.
      * @returns {{effectiveTileSize: number, gridOffsetX: number, gridOffsetY: number, totalGridWidth: number, totalGridHeight: number}}

--- a/js/managers/MicrocosmHeroEngine.js
+++ b/js/managers/MicrocosmHeroEngine.js
@@ -65,10 +65,23 @@ export class MicrocosmHeroEngine {
                 return;
             }
 
+            // Worker로 보내기 전, 복제 불가능한 데이터를 제거합니다.
+            const sanitizeUnit = (unit) => {
+                if (!unit) return null;
+                const { illustration, image, ...serializableUnit } = unit;
+                return serializableUnit;
+            };
+
+            const sanitizedHeroState = sanitizeUnit(instance.state);
+            const sanitizedBattleState = {
+                enemies: battleState.enemies.map(sanitizeUnit),
+                allies: battleState.allies.map(sanitizeUnit)
+            };
+
             instance.worker.postMessage({
                 type: 'DETERMINE_ACTION',
-                heroState: instance.state,
-                battleState: battleState
+                heroState: sanitizedHeroState,
+                battleState: sanitizedBattleState
             });
 
             instance.worker.onmessage = (event) => {

--- a/tests/unit/battleSimulationManagerUnitTests.js
+++ b/tests/unit/battleSimulationManagerUnitTests.js
@@ -146,5 +146,23 @@ export function runBattleSimulationManagerUnitTests(measureManager, assetLoaderM
         console.error("BattleSimulationManager: Error during isTileOccupied (dead unit). [FAIL]", e);
     }
 
+    // 테스트 9: getUnitById - 특정 ID의 유닛 검색
+    testCount++;
+    try {
+        const bsm = new BattleSimulationManager(measureManager, assetLoaderManager, idManager, logicManager);
+        const mockImage = new Image();
+        bsm.addUnit(mockUnit1, mockImage, 0, 0);
+        const found = bsm.getUnitById('u1');
+        const notFound = bsm.getUnitById('does_not_exist');
+        if (found && found.id === 'u1' && notFound === undefined) {
+            console.log("BattleSimulationManager: getUnitById returned correct unit and undefined when missing. [PASS]");
+            passCount++;
+        } else {
+            console.error("BattleSimulationManager: getUnitById did not behave as expected. [FAIL]", { found, notFound });
+        }
+    } catch (e) {
+        console.error("BattleSimulationManager: Error during getUnitById. [FAIL]", e);
+    }
+
     console.log(`--- BattleSimulationManager Unit Test End: ${passCount}/${testCount} tests passed ---`);
 }


### PR DESCRIPTION
## Summary
- add `getUnitById` to `BattleSimulationManager`
- sanitize hero data before posting to worker in `MicrocosmHeroEngine`
- extend BattleSimulationManager unit tests for the new function

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879e6f78ff88327b44742659e8289b3