### PR TITLE
Fix warrior tag inconsistencies

### DIFF
--- a/data/class.js
+++ b/data/class.js
@@ -22,7 +22,7 @@ export const CLASSES = {
         // 개별 영웅 생성 시 WarriorSkills 전체 목록에서 무작위로 부여됩니다.
         skills: [],
         moveRange: 3, // 전사의 이동 거리
-        tags: ['근접', '방어', '용병_클래스'] // ✨ 태그 추가
+        tags: ['근접', '방어', '용병', '전사']
     },
     // ✨ 전사 상위 클래스 추가
     WARRIOR_VALIANT: {
@@ -33,7 +33,7 @@ export const CLASSES = {
         // 상위 클래스 또한 스킬은 무작위로 결정됩니다.
         skills: [],
         moveRange: 3,
-        tags: ['근접', '방어', '용병_클래스', '고급']
+        tags: ['근접', '방어', '용병', '전사', '고급']
     },
     // 다른 클래스들이 여기에 추가됩니다.
     // MAGE: { id: 'class_mage', ... }

--- a/data/unit.js
+++ b/data/unit.js
@@ -32,7 +32,7 @@ export const UNITS = {
             attackRange: 1 // 기본 근접 사거리
         },
         spriteId: 'sprite_warrior_default',
-        tags: ['용병', '남자'] // ✨ 유닛 자체의 태그
+        tags: ['용병', '남자', '근접', '방어', '전사']
     }
     // 다른 유닛들이 여기에 추가됩니다.
     // ARCHER: { id: 'unit_archer_001', ... }

--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -16,6 +16,8 @@ export const WARRIOR_SKILLS = {
         name: '전투의 외침',
         type: SKILL_TYPES.BUFF,
         icon: 'assets/icons/skills/battle_cry.png',
+        tags: ['전사'],
+        requiredUserTags: ['전사'],
         aiFunction: 'battleCry',
         description: '자신의 공격력을 일시적으로 증가시키고 일반 공격을 수행합니다.',
         effect: {
@@ -30,6 +32,8 @@ export const WARRIOR_SKILLS = {
         name: '찢어발기기',
         type: SKILL_TYPES.DEBUFF,
         icon: 'assets/icons/skills/rending_strike.png',
+        tags: ['전사'],
+        requiredUserTags: ['전사'],
         probability: 0, // 평타에 묻어나는 스킬이라 자체 발동 확률은 0
         description: '일반 공격 시 일정 확률로 적에게 출혈 디버프를 부여합니다.',
         effect: {
@@ -42,6 +46,8 @@ export const WARRIOR_SKILLS = {
         name: '반격',
         type: SKILL_TYPES.REACTION,
         icon: 'assets/icons/skills/retaliate.png',
+        tags: ['전사'],
+        requiredUserTags: ['전사'],
         description: '공격을 받을 시 일정 확률로 즉시 80%의 피해로 반격합니다.',
         effect: {
             damageModifier: 0.8, // 반격 시 피해량 80%
@@ -55,6 +61,8 @@ export const WARRIOR_SKILLS = {
         description: '일반 공격 시 대상이 3턴간 받는 피해를 10% 증가시킵니다.',
         type: SKILL_TYPES.DEBUFF,
         icon: 'assets/icons/skills/shield-break.png',
+        tags: ['전사'],
+        requiredUserTags: ['전사'],
         effect: {
             statusEffectId: 'status_shield_break'
         }
@@ -66,6 +74,8 @@ export const WARRIOR_SKILLS = {
         description: '한 대상에게 빠르게 일반 공격을 2회 가합니다.',
         type: SKILL_TYPES.ACTIVE,
         icon: 'assets/icons/skills/double-strike-icon.png',
+        tags: ['전사'],
+        requiredUserTags: ['전사'],
         aiFunction: 'doubleStrike',
         cost: 25,
         range: 1,
@@ -84,6 +94,8 @@ export const WARRIOR_SKILLS = {
         description: '3턴 동안 받는 모든 피해가 15% 감소합니다.',
         type: 'active',
         icon: 'assets/icons/skills/stone-skin-icon.png',
+        tags: ['전사'],
+        requiredUserTags: ['전사'],
         aiFunction: 'stoneSkin',
         cost: 20,
         range: 0,
@@ -100,6 +112,8 @@ export const WARRIOR_SKILLS = {
         name: '강철 의지',
         type: SKILL_TYPES.PASSIVE,
         icon: 'assets/icons/skills/iron_will.png',
+        tags: ['전사'],
+        requiredUserTags: ['전사'],
         description: '잃은 체력에 비례하여 받는 피해량이 최대 30%까지 감소합니다.',
         effect: {
             // 이 효과는 ConditionalManager가 실시간으로 계산하므로

--- a/test/WarriorTagSystem.test.js
+++ b/test/WarriorTagSystem.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { TagManager } from '../js/managers/TagManager.js';
+import { CLASSES } from '../data/class.js';
+import { UNITS } from '../data/unit.js';
+import { WARRIOR_SKILLS } from '../data/warriorSkills.js';
+
+const tagManager = new TagManager({});
+
+// Verify warrior class and unit tags
+const warriorClass = CLASSES.WARRIOR;
+const warriorUnit = UNITS.WARRIOR;
+
+test('Warrior class and unit include warrior tag', () => {
+  assert.ok(warriorClass.tags.includes('전사'));
+  assert.ok(warriorUnit.tags.includes('전사'));
+});
+
+test('All warrior skills have warrior tag and are usable by warrior', () => {
+  for (const skill of Object.values(WARRIOR_SKILLS)) {
+    assert.ok(skill.tags.includes('전사'));
+    assert.deepEqual(skill.requiredUserTags, ['전사']);
+    assert.ok(tagManager.canUseSkill(warriorClass, skill));
+  }
+});

--- a/tests/unit/tagManagerUnitTests.js
+++ b/tests/unit/tagManagerUnitTests.js
@@ -1,4 +1,5 @@
 import { TagManager } from '../../js/managers/TagManager.js';
+import { WARRIOR_SKILLS } from '../../data/warriorSkills.js';
 
 export function runTagManagerUnitTests(idManager) {
     console.log("--- TagManager Unit Test Start ---");
@@ -11,7 +12,7 @@ export function runTagManagerUnitTests(idManager) {
         get: async (id) => {
             switch (id) {
                 case 'class_warrior':
-                    return { id: 'class_warrior', name: '전사', tags: ['근접', '방어', '용병'] };
+                    return { id: 'class_warrior', name: '전사', tags: ['근접', '방어', '용병', '전사'] };
                 case 'class_mage':
                     return { id: 'class_mage', name: '마법사', tags: ['원거리', '마법', '용병'] };
                 case 'class_skeleton':
@@ -159,7 +160,7 @@ export function runTagManagerUnitTests(idManager) {
     testCount++;
     try {
         const tm = new TagManager(mockIdManager);
-        const isValid = await tm.validateDataTags('class_warrior', ['근접', '방어', '용병']);
+        const isValid = await tm.validateDataTags('class_warrior', ['근접', '방어', '용병', '전사']);
         if (isValid) {
             console.log("TagManager: validateDataTags succeeded for Warrior. [PASS]");
             passCount++;
@@ -183,6 +184,23 @@ export function runTagManagerUnitTests(idManager) {
         }
     } catch (e) {
         console.error("TagManager: Error during validateDataTags (missing) test. [FAIL]", e);
+    }
+
+    // 테스트 11: Warrior class can use all warrior skills
+    testCount++;
+    try {
+        const tm = new TagManager(mockIdManager);
+        const warriorData = await mockIdManager.get('class_warrior');
+        const allUsable = Object.values(WARRIOR_SKILLS).every(skill => tm.canUseSkill(warriorData, skill));
+        const allTagged = Object.values(WARRIOR_SKILLS).every(skill => tm.hasTag(skill, '전사'));
+        if (allUsable && allTagged) {
+            console.log("TagManager: Warrior can use all warrior skills with correct tags. [PASS]");
+            passCount++;
+        } else {
+            console.error("TagManager: Warrior skills tag validation failed. [FAIL]");
+        }
+    } catch (e) {
+        console.error("TagManager: Error during warrior skill tag test. [FAIL]", e);
     }
 
     console.log(`--- TagManager Unit Test End: ${passCount}/${testCount} tests passed ---`);


### PR DESCRIPTION
## Summary
- mark warrior skills as warrior-only
- align warrior class/unit tag lists
- verify warrior tags in TagManager unit tests
- add new WarriorTagSystem node test

## Testing
- `npm test` *(fails: npm not found)*
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6879e882f94c8327818b3712e95195c8