### PR TITLE
Begin AI module refactor

### DIFF
--- a/js/modules/AIModule.js
+++ b/js/modules/AIModule.js
@@ -1,0 +1,52 @@
+import { AIEngine } from '../managers/AIEngine.js';
+import { BasicAIManager } from '../managers/BasicAIManager.js';
+import { ClassAIManager } from '../managers/ClassAIManager.js';
+import { MetaAIManager } from '../managers/MetaAIManager.js';
+import { MonsterAI } from '../managers/MonsterAI.js';
+import { SkillAIManager } from '../managers/SkillAIManager.js';
+import { WarriorSkillsAI } from '../managers/warriormanager.js';
+
+/**
+ * Groups all AI related managers so they can be created and accessed together.
+ */
+export class AIModule {
+    constructor({
+        idManager,
+        battleSimulationManager,
+        eventManager,
+        slotMachineManager,
+        targetingManager,
+        positionManager,
+        commonManagersForSkills
+    }) {
+        // Managers that often change together are instantiated here
+        this.basicAIManager = new BasicAIManager(targetingManager, positionManager);
+        this.monsterAI = new MonsterAI(this.basicAIManager);
+        this.warriorSkillsAI = new WarriorSkillsAI(commonManagersForSkills);
+        this.classAIManager = new ClassAIManager(
+            idManager,
+            battleSimulationManager,
+            this.basicAIManager,
+            this.warriorSkillsAI,
+            targetingManager,
+            this.monsterAI,
+            slotMachineManager,
+            eventManager
+        );
+
+        // Less frequently used AI helpers
+        this.aiEngine = new AIEngine();
+        this.metaAIManager = new MetaAIManager();
+        this.skillAIManager = new SkillAIManager();
+    }
+}
+
+export {
+    AIEngine,
+    BasicAIManager,
+    ClassAIManager,
+    MetaAIManager,
+    MonsterAI,
+    SkillAIManager,
+    WarriorSkillsAI
+};


### PR DESCRIPTION
## Summary
- group AI-related managers into a new `AIModule`
- update `GameEngine` to use the new module and expose it via getter

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879f1b683a08327b3251c7e77d27c0c