### PR TITLE
Fix hero microcosm skill execution

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -496,7 +496,7 @@
             });
 
             document.getElementById('testDamageCalculationBtn').addEventListener('click', () => {
-                gameEngine.getSceneEngine().setCurrentScene('battleScene');
+                gameEngine.getSceneEngine().setCurrentScene('combatScreen');
                 gameEngine.getUIEngine().setUIState('combatScreen');
                 gameEngine.getCameraEngine().reset();
 

--- a/js/managers/LogicManager.js
+++ b/js/managers/LogicManager.js
@@ -35,7 +35,7 @@ export class LogicManager {
             // 영지 씬은 캔버스와 동일한 크기를 사용
             contentWidth = canvasWidth;
             contentHeight = canvasHeight;
-        } else if (currentSceneName === 'battleScene') {
+        } else if (currentSceneName === 'combatScreen') {
             // 전투 씬의 경우, 전체 캔버스 영역을 콘텐츠로 간주합니다.
             // BattleStageManager가 배경을 전체 캔버스에 그리므로
             // 카메라가 이 전체 영역을 프레임해야 합니다.

--- a/js/managers/TurnEngine.js
+++ b/js/managers/TurnEngine.js
@@ -116,6 +116,16 @@ export class TurnEngine {
                 if (this.microcosmHeroEngine.hasHeroMicrocosm(unit.id)) {
                     try {
                         action = await this.microcosmHeroEngine.determineHeroAction(unit.id, battleState);
+
+                        // ✨ MicrocosmHeroEngine은 execute 함수를 제공하지 않으므로
+                        // 스킬 액션일 경우 ClassAIManager 로직을 참고해 동적으로 할당합니다.
+                        if (action && action.actionType === 'skill' && !action.execute) {
+                            const skillData = await this.classAIManager.idManager.get(action.skillId);
+                            const targetUnit = this.battleSimulationManager.getUnitById(action.targetId);
+                            if (skillData && targetUnit) {
+                                action.execute = () => this.classAIManager.executeSkillAI(unit, skillData, targetUnit);
+                            }
+                        }
                     } catch (e) {
                         if (GAME_DEBUG_MODE) console.warn(`[TurnEngine] Microcosm action failed for ${unit.name}:`, e);
                     }

--- a/tests/unit/logicManagerUnitTests.js
+++ b/tests/unit/logicManagerUnitTests.js
@@ -23,7 +23,7 @@ export function runLogicManagerUnitTests(logicManager) {
         getCurrentSceneName: () => 'territoryScene'
     };
     const mockSceneManagerBattle = {
-        getCurrentSceneName: () => 'battleScene'
+        getCurrentSceneName: () => 'combatScreen'
     };
     const mockSceneManagerUnknown = {
         getCurrentSceneName: () => 'unknownScene'

--- a/tests/unit/vfxManagerUnitTests.js
+++ b/tests/unit/vfxManagerUnitTests.js
@@ -17,7 +17,7 @@ export function runVFXManagerUnitTests() {
     const mockRenderer = { canvas: { width: 800, height: 600 }, ctx: {} };
     const mockMeasureManager = new MeasureManager();
     const mockCameraEngine = {};
-    const mockLogicManager = new LogicManager(mockMeasureManager, { getCurrentSceneName: () => 'battleScene' });
+    const mockLogicManager = new LogicManager(mockMeasureManager, { getCurrentSceneName: () => 'combatScreen' });
     const mockEventManager = new EventManager();
 
     const mockAnimationManager = new AnimationManager(mockMeasureManager);


### PR DESCRIPTION
## Summary
- link hero microcosm skill actions with `ClassAIManager.executeSkillAI`
- recognize `combatScreen` scene in `LogicManager`
- align debug page and tests to use `combatScreen`

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6879f4512f5c8327840be41324f06267