### PR TITLE
Include attacker ID in damage events

### DIFF
--- a/js/managers/BattleCalculationManager.js
+++ b/js/managers/BattleCalculationManager.js
@@ -28,7 +28,7 @@ export class BattleCalculationManager {
     }
 
     async _handleWorkerMessage(event) {
-        const { type, unitId, hpDamageDealt, barrierDamageDealt } = event.data;
+        const { type, unitId, attackerId, hpDamageDealt, barrierDamageDealt } = event.data; // attackerId 추가
 
         if (type === GAME_EVENTS.DAMAGE_CALCULATED) {
             console.log(`[BattleCalculationManager] Damage result for ${unitId}: HP Damage = ${hpDamageDealt}, Barrier Damage = ${barrierDamageDealt}`);
@@ -38,13 +38,13 @@ export class BattleCalculationManager {
                 this.unitStatManager.dealDamage(unitId, hpDamageDealt + barrierDamageDealt);
 
                 if (barrierDamageDealt > 0) {
-                    this.eventManager.emit(GAME_EVENTS.DISPLAY_DAMAGE, { unitId: unitId, damage: barrierDamageDealt, color: 'yellow' });
+                    this.eventManager.emit(GAME_EVENTS.DISPLAY_DAMAGE, { unitId: unitId, attackerId: attackerId, damage: barrierDamageDealt, color: 'yellow' }); // 공격자 ID 포함
                     if (hpDamageDealt > 0) {
                         await this.delayEngine.waitFor(100);
                     }
                 }
                 if (hpDamageDealt > 0) {
-                    this.eventManager.emit(GAME_EVENTS.DISPLAY_DAMAGE, { unitId: unitId, damage: hpDamageDealt, color: 'red' });
+                    this.eventManager.emit(GAME_EVENTS.DISPLAY_DAMAGE, { unitId: unitId, attackerId: attackerId, damage: hpDamageDealt, color: 'red' }); // 공격자 ID 포함
                 }
 
                 if (unitToUpdate.currentHp <= 0) {
@@ -82,8 +82,7 @@ export class BattleCalculationManager {
         const damageReduction = this.modifierEngine.getDamageReduction(targetUnitId);
 
         const payload = {
-            attackerStats: attackerUnit.fullUnitData ? attackerUnit.fullUnitData.baseStats : attackerUnit.baseStats,
-            targetStats: targetUnit.fullUnitData ? targetUnit.fullUnitData.baseStats : targetUnit.baseStats,
+            attackerUnitId: attackerUnitId, // 워커에 공격자 ID 전달
             attackerStats: attackerUnit.fullUnitData ? attackerUnit.fullUnitData.baseStats : attackerUnit.baseStats,
             targetStats: targetUnit.fullUnitData ? targetUnit.fullUnitData.baseStats : targetUnit.baseStats,
             currentTargetHp: targetUnit.currentHp,

--- a/js/workers/battleCalculationWorker.js
+++ b/js/workers/battleCalculationWorker.js
@@ -6,7 +6,8 @@ self.onmessage = (event) => {
     switch (type) {
         case 'CALCULATE_DAMAGE': {
             // ✨ payload에서 defender's damage reduction 값을 추가로 받음
-            const { attackerStats, targetStats, skillData, currentTargetHp, currentTargetBarrier, maxBarrier, preCalculatedDamageRoll, damageReduction } = payload;
+            // attackerUnitId도 함께 전달받아야 메인 스레드에서 사용 가능
+            const { attackerStats, targetStats, skillData, currentTargetHp, currentTargetBarrier, maxBarrier, preCalculatedDamageRoll, damageReduction, attackerUnitId } = payload; // attackerUnitId 추가
 
             // 방어력 적용
             let finalDamage = preCalculatedDamageRoll - targetStats.defense;
@@ -43,6 +44,7 @@ self.onmessage = (event) => {
             self.postMessage({
                 type: 'DAMAGE_CALCULATED',
                 unitId: payload.targetUnitId,
+                attackerId: attackerUnitId, // 공격자 ID를 함께 전송
                 newHp: newHp,
                 newBarrier: newBarrier,          // ✨ 업데이트된 배리어 값 반환
                 hpDamageDealt: hpDamageDealt,    // ✨ HP로 들어간 데미지 반환


### PR DESCRIPTION
## Summary
- pass attacker ID with damage calculation worker results
- forward attacker ID in `BattleCalculationManager`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a0aa4e99483278f20043caec21bb4