### PR TITLE
Fix warrior double strike

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -436,7 +436,8 @@ export class GameEngine {
             animationManager: this.animationManager,
             measureManager: this.measureManager,
             idManager: this.idManager,
-            movingManager: this.movingManager
+            movingManager: this.movingManager,
+            rangeManager: this.rangeManager
         };
         this.warriorSkillsAI = new WarriorSkillsAI(commonManagersForSkills);
 


### PR DESCRIPTION
## Summary
- pass RangeManager into WarriorSkillsAI so double-strike checks range correctly

## Testing
- `npm test`
- `python3 -m http.server 8000 &` + `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a0e2569488327aaffc94e54212343