### PR TITLE
Fix double strike movement

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -303,7 +303,8 @@ export class GameEngine {
             this.battleSimulationManager,
             this.animationManager,
             this.delayEngine,
-            this.coordinateManager
+            this.coordinateManager,
+            null // positionManager will be set after initialization
         );
 
         // ------------------------------------------------------------------
@@ -406,6 +407,8 @@ export class GameEngine {
         // ✨ 신규 매니저들 초기화 (BattleSimulationManager 이후에)
         this.targetingManager = new TargetingManager(this.battleSimulationManager);
         this.positionManager = new PositionManager(this.battleSimulationManager);
+        // MovingManager가 위치 정보를 활용할 수 있도록 PositionManager 연결
+        this.movingManager.positionManager = this.positionManager;
 
         // ✨ BasicAIManager에 신규 매니저들 주입
         this.basicAIManager = new BasicAIManager(this.targetingManager, this.positionManager);
@@ -437,7 +440,8 @@ export class GameEngine {
             measureManager: this.measureManager,
             idManager: this.idManager,
             movingManager: this.movingManager,
-            rangeManager: this.rangeManager
+            rangeManager: this.rangeManager,
+            positionManager: this.positionManager
         };
         this.warriorSkillsAI = new WarriorSkillsAI(commonManagersForSkills);
 

--- a/js/managers/MovingManager.js
+++ b/js/managers/MovingManager.js
@@ -10,7 +10,7 @@ export class MovingManager {
      * @param {DelayEngine} delayEngine - 애니메이션 지연을 위한 인스턴스
      * @param {CoordinateManager} coordinateManager - 좌표 유효성 검사를 위한 인스턴스
      */
-    constructor(battleSimulationManager, animationManager, delayEngine, coordinateManager) {
+    constructor(battleSimulationManager, animationManager, delayEngine, coordinateManager, positionManager = null) {
         if (GAME_DEBUG_MODE) console.log("\uD83D\uDE80 MovingManager initialized. Ready for special unit movements. \uD83D\uDE80");
         if (!battleSimulationManager || !animationManager || !delayEngine || !coordinateManager) {
             throw new Error("[MovingManager] Missing essential dependencies. Cannot initialize.");
@@ -19,6 +19,7 @@ export class MovingManager {
         this.animationManager = animationManager;
         this.delayEngine = delayEngine;
         this.coordinateManager = coordinateManager;
+        this.positionManager = positionManager;
     }
 
     /**
@@ -87,6 +88,57 @@ export class MovingManager {
             if (GAME_DEBUG_MODE) console.warn(`[MovingManager] Unit ${unit.name} failed to move to (${finalDest.x},${finalDest.y}) during charge.`);
             return false;
         }
+    }
+
+    /**
+     * 이동 범위 내에서 목표를 향해 최대한 전진합니다. 도달할 수 없다면 가능한 한 가까운 타일로 이동합니다.
+     * @param {object} unit - 이동할 유닛
+     * @param {number} targetGridX - 목표 X 좌표
+     * @param {number} targetGridY - 목표 Y 좌표
+     * @param {number} moveRange - 이동 가능 범위
+     * @returns {Promise<boolean>} 이동 성공 여부
+     */
+    async advanceTowards(unit, targetGridX, targetGridY, moveRange) {
+        if (!this.positionManager) {
+            if (GAME_DEBUG_MODE) console.warn('[MovingManager] advanceTowards called without PositionManager.');
+            return false;
+        }
+
+        const path = this.positionManager.findPath({ x: unit.gridX, y: unit.gridY }, { x: targetGridX, y: targetGridY });
+        if (!path || path.length < 2) {
+            if (GAME_DEBUG_MODE) console.log(`[MovingManager] No path found for ${unit.name} towards (${targetGridX},${targetGridY}).`);
+            return false;
+        }
+
+        const maxIndex = Math.min(moveRange, path.length - 1);
+        let destination = null;
+        for (let i = maxIndex; i > 0; i--) {
+            const step = path[i];
+            if (!this.coordinateManager.isTileOccupied(step.x, step.y, unit.id)) {
+                destination = step;
+                break;
+            }
+        }
+
+        if (!destination) {
+            if (GAME_DEBUG_MODE) console.log(`[MovingManager] No reachable tile found for ${unit.name} within range ${moveRange}.`);
+            return false;
+        }
+
+        const startX = unit.gridX;
+        const startY = unit.gridY;
+        const moved = this.battleSimulationManager.moveUnit(unit.id, destination.x, destination.y);
+
+        if (moved) {
+            await this.animationManager.queueMoveAnimation(unit.id, startX, startY, destination.x, destination.y);
+            await this.delayEngine.waitFor(this.animationManager.getAnimationDuration(startX, startY, destination.x, destination.y));
+            if (GAME_DEBUG_MODE) console.log(`[MovingManager] ${unit.name} advanced towards (${targetGridX},${targetGridY}) to (${destination.x},${destination.y}).`);
+            return true;
+        } else if (GAME_DEBUG_MODE) {
+            console.warn(`[MovingManager] ${unit.name} failed to advance towards (${destination.x},${destination.y}).`);
+        }
+
+        return false;
     }
 }
 

--- a/js/managers/warriorSkillsAI.js
+++ b/js/managers/warriorSkillsAI.js
@@ -147,10 +147,17 @@ export class WarriorSkillsAI {
         if (!inRange) {
             if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] Target out of range. Moving closer...`);
             const moveRange = userUnit.baseStats.moveRange || 1;
-            const moved = await this.managers.movingManager.chargeMove(userUnit, targetUnit.gridX, targetUnit.gridY, moveRange);
+            let moved = await this.managers.movingManager.chargeMove(userUnit, targetUnit.gridX, targetUnit.gridY, moveRange);
+
+            // chargeMove가 실패하면 가능한 한 목표 방향으로 이동 시도
             if (!moved) {
-                if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] Could not move to target. Double Strike cancelled.`);
-                return; // 이동에 실패하면 스킬 취소
+                moved = await this.managers.movingManager.advanceTowards?.(userUnit, targetUnit.gridX, targetUnit.gridY, moveRange);
+            }
+
+            // 이동 후에도 사거리 밖이면 스킬 취소
+            if (!moved || !this.managers.rangeManager.isTargetInRange(userUnit, targetUnit)) {
+                if (GAME_DEBUG_MODE) console.log(`[WarriorSkillsAI] Could not reach target this turn. Double Strike cancelled.`);
+                return;
             }
         }
 


### PR DESCRIPTION
## Summary
- update MovingManager to accept PositionManager and add `advanceTowards`
- wire PositionManager through GameEngine to MovingManager and WarriorSkillsAI
- update `doubleStrike` to move toward distant targets before attacking

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a11310c6c8327a8442345bff995f1