### PR TITLE
Fix status icon duplication

### DIFF
--- a/data/statusEffects.js
+++ b/data/statusEffects.js
@@ -32,6 +32,7 @@ export const STATUS_EFFECTS = {
         id: 'status_bleed',
         name: '출혈',
         type: STATUS_EFFECT_TYPES.DEBUFF,
+        icon: 'assets/icons/status_effects/bleed.png',
         description: '이동하거나 공격할 때 추가 피해를 입습니다. 이 효과는 중첩될 수 있습니다.',
         duration: 3, // 스택이 쌓일 때마다 지속시간이 초기화됩니다.
         stackable: true, // ✨ 스택 가능 여부

--- a/js/managers/PassiveIconManager.js
+++ b/js/managers/PassiveIconManager.js
@@ -36,16 +36,6 @@ export class PassiveIconManager {
                 if (icon) icons.push(icon);
             }
 
-            if (this.statusEffectManager) {
-                const effects = this.statusEffectManager.getUnitActiveEffects(unit.id);
-                if (effects) {
-                    for (const [effectId] of effects.entries()) {
-                        const icon = this.skillIconManager.getSkillIcon(effectId);
-                        if (icon && icon.width > 1) icons.push(icon);
-                    }
-                }
-            }
-
             icons.forEach((icon, idx) => {
                 const baseIconSize = effectiveTileSize * this.iconSizeRatio;
                 const iconX = drawX + idx * (baseIconSize + 2);

--- a/js/managers/StatusIconManager.js
+++ b/js/managers/StatusIconManager.js
@@ -25,7 +25,8 @@ export class StatusIconManager {
         this.turnCountManager = turnCountManager;
 
         this.iconSizeRatio = 0.2;
-        this.iconOffsetYRatio = 0.6;
+        // 아이콘은 HP 바 아래 한 곳에만 표시되도록 오프셋을 낮춥니다.
+        this.iconOffsetYRatio = 0.1;
         this.iconSpacing = 5;
     }
 


### PR DESCRIPTION
## Summary
- prevent status icons from rendering twice
- display buff icons below HP bar
- load bleed icon for status effects

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a18cdfeec83278f70969eeb49d2cf