### PR TITLE
Add warrior healing reaction skill

### DIFF
--- a/data/warriorSkills.js
+++ b/data/warriorSkills.js
@@ -55,6 +55,19 @@ export const WARRIOR_SKILLS = {
         }
     },
 
+    SMALL_HEALING_POTION: {
+        id: 'skill_warrior_small_healing_potion',
+        name: '스몰 힐링 포션',
+        type: SKILL_TYPES.REACTION,
+        icon: 'assets/icons/skills/small-healing-potion.png',
+        tags: ['전사'],
+        requiredUserTags: ['전사'],
+        description: '공격을 받을 때 자신의 체력의 5%를 회복합니다.',
+        effect: {
+            healPercent: 0.05
+        }
+    },
+
     SHIELD_BREAK: {
         id: 'skill_warrior_shield_break',
         name: '쉴드 브레이크',

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -502,7 +502,8 @@ export class GameEngine {
             this.diceEngine,
             this.battleSimulationManager,
             this.battleCalculationManager,
-            this.delayEngine
+            this.delayEngine,
+            this.unitStatManager
         );
 
         // HeroManager는 UnitSpriteEngine이 준비된 이후 생성한다
@@ -582,7 +583,7 @@ export class GameEngine {
         this.gameLoop = new GameLoop(this._update, this._draw);
 
         // ✨ _initAsyncManagers에서 로드할 총 에셋 및 데이터 수를 수동으로 계산
-        const expectedDataAndAssetCount = 9 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 4; // 9(기존) + 5(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 4(전사 상태 스프라이트)
+        const expectedDataAndAssetCount = 9 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 4; // 9(기존) + 6(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 4(전사 상태 스프라이트)
         this.assetLoaderManager.setTotalAssetsToLoad(expectedDataAndAssetCount);
 
         // 초기화 과정의 비동기 처리

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -372,7 +372,7 @@ export class VFXManager {
 
             ctx.save();
             ctx.globalAlpha = alpha;
-            ctx.fillStyle = dmgNum.color || ((dmgNum.damage > 0) ? '#FF4500' : '#ADFF2F');
+            ctx.fillStyle = dmgNum.color || ((dmgNum.damage > 0) ? '#FF4500' : '#00FF00');
             const baseFontSize = this.measureManager.get('vfx.damageNumberBaseFontSize');
             const scaleFactor = this.measureManager.get('vfx.damageNumberScaleFactor');
             ctx.font = `bold ${baseFontSize + (1 - progress) * scaleFactor}px Arial`;


### PR DESCRIPTION
## Summary
- add `SMALL_HEALING_POTION` reaction skill to warrior skills
- allow ReactionSkillManager to heal units when attacked
- pass UnitStatManager into ReactionSkillManager
- color healing numbers bright green
- update asset loading comment

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a1c704b5883278c271cb7d14d5210