### PR TITLE
Add skill type color support

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -68,4 +68,12 @@ export const SKILL_TYPES = {
     BUFF: 'buff'
 };
 
+export const SKILL_TYPE_COLORS = {
+    [SKILL_TYPES.BUFF]: 'blue',
+    [SKILL_TYPES.DEBUFF]: 'red',
+    [SKILL_TYPES.ACTIVE]: 'orange',
+    [SKILL_TYPES.REACTION]: 'purple',
+    [SKILL_TYPES.PASSIVE]: 'green'
+};
+
 export const GAME_DEBUG_MODE = true; // ✨ 디버그 모드 플래그 (배포 시 false로 설정)

--- a/js/managers/ReactionSkillManager.js
+++ b/js/managers/ReactionSkillManager.js
@@ -51,7 +51,8 @@ export class ReactionSkillManager {
 
                 this.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
                     unitId: defenderId,
-                    skillName: skillData.name
+                    skillName: skillData.name,
+                    skillType: skillData.type
                 });
 
                 await this.delayEngine.waitFor(250);
@@ -85,7 +86,8 @@ export class ReactionSkillManager {
 
                 this.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
                     unitId: defenderId,
-                    skillName: skillData.name
+                    skillName: skillData.name,
+                    skillType: skillData.type
                 });
 
                 const healAmount = Math.floor(defender.baseStats.hp * skillData.effect.healPercent);

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -1,6 +1,6 @@
 // js/managers/VFXManager.js
 
-import { GAME_EVENTS, GAME_DEBUG_MODE } from '../constants.js';
+import { GAME_EVENTS, GAME_DEBUG_MODE, SKILL_TYPE_COLORS } from '../constants.js';
 
 export class VFXManager {
     // animationManager를 추가로 받아 유닛의 애니메이션 위치를 참조합니다.
@@ -52,7 +52,7 @@ export class VFXManager {
         });
 
         this.eventManager.subscribe(GAME_EVENTS.DISPLAY_SKILL_NAME, (data) => {
-            this.addSkillName(data.unitId, data.skillName);
+            this.addSkillName(data.unitId, data.skillName, data.skillType);
         });
         if (GAME_DEBUG_MODE) console.log("[VFXManager] Subscribed to 'displaySkillName' event.");
     }
@@ -86,12 +86,14 @@ export class VFXManager {
      * @param {string} unitId - 스킬을 사용한 유닛의 ID
      * @param {string} skillName - 표시할 스킬 이름
      */
-    addSkillName(unitId, skillName) {
+    addSkillName(unitId, skillName, skillType) {
         const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === unitId);
         if (!unit) {
             if (GAME_DEBUG_MODE) console.warn(`[VFXManager] Cannot show skill name for unknown unit: ${unitId}`);
             return;
         }
+
+        const color = SKILL_TYPE_COLORS[skillType] || '#FFD700';
 
         this.activeSkillNames.push({
             unitId,
@@ -99,7 +101,7 @@ export class VFXManager {
             startTime: performance.now(),
             duration: 1500,
             floatSpeed: 0.04,
-            color: '#FFD700'
+            color
         });
         if (GAME_DEBUG_MODE) console.log(`[VFXManager] Added skill name: '${skillName}' for ${unit.name}`);
     }

--- a/js/managers/warriorSkillsAI.js
+++ b/js/managers/warriorSkillsAI.js
@@ -42,7 +42,8 @@ export class WarriorSkillsAI {
         // 스킬 이름 표시 이벤트
         this.managers.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
             unitId: userUnit.id,
-            skillName: skillData.name
+            skillName: skillData.name,
+            skillType: skillData.type
         });
 
         // 1. 스킬 시전 시각 효과
@@ -117,7 +118,8 @@ export class WarriorSkillsAI {
 
         this.managers.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
             unitId: userUnit.id,
-            skillName: skillData.name
+            skillName: skillData.name,
+            skillType: skillData.type
         });
         this.managers.workflowManager.triggerStatusEffectApplication(targetUnit.id, skillData.effect.statusEffectId);
         await this.managers.delayEngine.waitFor(100);
@@ -147,7 +149,8 @@ export class WarriorSkillsAI {
 
         this.managers.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
             unitId: userUnit.id,
-            skillName: skillData.name
+            skillName: skillData.name,
+            skillType: skillData.type
         });
         await this.managers.delayEngine.waitFor(300);
 
@@ -213,7 +216,8 @@ export class WarriorSkillsAI {
 
         this.managers.eventManager.emit(GAME_EVENTS.DISPLAY_SKILL_NAME, {
             unitId: userUnit.id,
-            skillName: skillData.name
+            skillName: skillData.name,
+            skillType: skillData.type
         });
 
         const effectId = skillData.effect.appliesEffect;

--- a/tests/unit/warriorSkillsAIUnitTests.js
+++ b/tests/unit/warriorSkillsAIUnitTests.js
@@ -58,7 +58,7 @@ export function runWarriorSkillsAIUnitTests() {
             const skillNameEvent = mockManagers.eventManager.emittedEvents.find(e => e.eventName === GAME_EVENTS.DISPLAY_SKILL_NAME);
             const effectApplied = mockManagers.workflowManager.triggeredEffects.some(e => e.statusEffectId === 'status_battle_cry');
 
-            if (skillNameEvent && effectApplied) {
+            if (skillNameEvent && skillNameEvent.data.skillType === WARRIOR_SKILLS.BATTLE_CRY.type && effectApplied) {
                 if (GAME_DEBUG_MODE) console.log("WarriorSkillsAI: Battle Cry executed correctly. [PASS]");
                 passCount++;
             } else {
@@ -85,7 +85,7 @@ export function runWarriorSkillsAIUnitTests() {
             const attackEvents = mockManagers.eventManager.emittedEvents.filter(e => e.eventName === GAME_EVENTS.UNIT_ATTACK_ATTEMPT && e.data.skillId === null);
             const damageRequests = mockManagers.battleCalculationManager.requests;
 
-            if (skillNameEvent && attackEvents.length === 2 && damageRequests.length === 2) {
+            if (skillNameEvent && skillNameEvent.data.skillType === WARRIOR_SKILLS.DOUBLE_STRIKE.type && attackEvents.length === 2 && damageRequests.length === 2) {
                 if (GAME_DEBUG_MODE) console.log("WarriorSkillsAI: Double Strike executed two basic attacks correctly. [PASS]");
                 passCount++;
             } else {
@@ -110,7 +110,7 @@ export function runWarriorSkillsAIUnitTests() {
             const skillNameEvent = mockManagers.eventManager.emittedEvents.find(e => e.eventName === GAME_EVENTS.DISPLAY_SKILL_NAME && e.data.skillName === '스톤 스킨');
             const effectApplied = mockManagers.workflowManager.triggeredEffects.some(e => e.statusEffectId === 'status_stone_skin' && e.unitId === 'w1');
 
-            if (skillNameEvent && effectApplied) {
+            if (skillNameEvent && skillNameEvent.data.skillType === WARRIOR_SKILLS.STONE_SKIN.type && effectApplied) {
                 if (GAME_DEBUG_MODE) console.log("WarriorSkillsAI: Stone Skin applied buff to self correctly. [PASS]");
                 passCount++;
             } else {


### PR DESCRIPTION
## Summary
- map skill type to display color in constants
- show colored skill names in VFXManager
- pass skill type when triggering `displaySkillName`
- update warrior skill AI unit tests

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a2579ac1083279ed0fb97bf780f29