### PR TITLE
Normalize SKILL_EXECUTED event payload

### DIFF
--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -81,7 +81,7 @@ export class ClassAIManager {
     }
     
     async executeSkillAI(userUnit, skillData, targetUnit) {
-        this.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, { unitId: userUnit.id, skillId: skillData.id });
+        this.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, { userId: userUnit.id, skillId: skillData.id });
         if (!skillData.aiFunction) {
             if (GAME_DEBUG_MODE) console.warn(`[ClassAIManager] Skill '${skillData.name}' has no 'aiFunction' property to execute.`);
             return;

--- a/js/managers/EventManager.js
+++ b/js/managers/EventManager.js
@@ -49,7 +49,7 @@ export class EventManager {
                 if (GAME_DEBUG_MODE) console.log(`[EventManager] ${sourceUnitId} 사망으로 인한 광역 공포(${radius} 범위) 발동!`);
             }
             // 이 시점에서 다시 이벤트를 발생시킬 수도 있습니다.
-            this.emit(GAME_EVENTS.SKILL_EXECUTED, { skillName, targetUnitId, amount, sourceUnitId, radius }); // ✨ 상수 사용
+            this.emit(GAME_EVENTS.SKILL_EXECUTED, { skillName, targetUnitId, amount, userId: sourceUnitId, radius }); // ✨ 상수 사용
         }
     }
 

--- a/js/managers/OneTwoThreeManager.js
+++ b/js/managers/OneTwoThreeManager.js
@@ -21,10 +21,10 @@ export class OneTwoThreeManager {
 
     /**
      * 스킬이 실행되었을 때 호출됩니다.
-     * @param {object} data - { unitId, skillId }
+     * @param {object} data - { userId, skillId }
      */
-    _onSkillExecuted({ unitId, skillId }) {
-        const unit = this.battleSimulationManager.getUnitById(unitId);
+    _onSkillExecuted({ userId, skillId }) {
+        const unit = this.battleSimulationManager.getUnitById(userId);
         if (!unit || !unit.skillSlots) return;
 
         const slotIndex = unit.skillSlots.indexOf(skillId);
@@ -35,7 +35,7 @@ export class OneTwoThreeManager {
             
             // "N번째 스킬 슬롯이 활성화되었다!" 라고 새로운 이벤트를 외쳐줍니다.
             this.eventManager.emit(GAME_EVENTS.SKILL_SLOT_ACTIVATED, {
-                unitId: unitId,
+                unitId: userId,
                 skillId: skillId,
                 slotIndex: slotIndex // 0-based index (0, 1, 2)
             });

--- a/js/managers/PassiveSkillManager.js
+++ b/js/managers/PassiveSkillManager.js
@@ -50,7 +50,7 @@ export class PassiveSkillManager {
                 if (this.diceEngine.getRandomFloat() < finalChance) {
                     if (GAME_DEBUG_MODE) console.log(`[PassiveSkillManager] ${attacker.name}'s '${skillData.name}' triggered on ${targetId}!`);
                     this.eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, {
-                        unitId: attackerId,
+                        userId: attackerId,
                         skillId: skillData.id
                     });
                     this.workflowManager.triggerStatusEffectApplication(targetId, skillData.effect.statusEffectId);

--- a/tests/unit/eventManagerUnitTests.js
+++ b/tests/unit/eventManagerUnitTests.js
@@ -1,3 +1,5 @@
+import { GAME_EVENTS } from '../../js/constants.js';
+
 export function runEventManagerTests(eventManager) {
     console.log("--- EventManager Test Start ---");
 
@@ -41,7 +43,26 @@ export function runEventManagerTests(eventManager) {
         setTimeout(() => {
             console.log("EventManager: 'unitAttack' event processed by worker's small engine. Visually check console for '흡혈' skill trigger messages. [INFO]");
             passCount++;
-            console.log(`--- EventManager Test End: ${passCount}/${testCount} tests passed ---`);
+
+            testCount++;
+            let skillEventReceived = false;
+            const skillPayload = { userId: 'tester1', skillId: 'skill001' };
+            eventManager.subscribe(GAME_EVENTS.SKILL_EXECUTED, data => {
+                if (data.userId === skillPayload.userId && data.skillId === skillPayload.skillId) {
+                    skillEventReceived = true;
+                }
+            });
+            eventManager.emit(GAME_EVENTS.SKILL_EXECUTED, skillPayload);
+
+            setTimeout(() => {
+                if (skillEventReceived) {
+                    console.log("EventManager: SKILL_EXECUTED propagated userId correctly. [PASS]");
+                    passCount++;
+                } else {
+                    console.error("EventManager: SKILL_EXECUTED userId mismatch or event missing. [FAIL]");
+                }
+                console.log(`--- EventManager Test End: ${passCount}/${testCount} tests passed ---`);
+            }, 100);
         }, 100);
     }, 100);
 }


### PR DESCRIPTION
## Summary
- standardize SKILL_EXECUTED event to carry `userId`
- update event consumers to read `userId`
- extend EventManager unit tests to cover the new payload

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a388ac8ec8327b27394e37638698a