### PR TITLE
Adjust passive debuff timing

### DIFF
--- a/js/managers/BattleCalculationManager.js
+++ b/js/managers/BattleCalculationManager.js
@@ -57,6 +57,14 @@ export class BattleCalculationManager {
                     this.eventManager.emit(GAME_EVENTS.DISPLAY_DAMAGE, { unitId: unitId, attackerId: attackerId, damage: hpDamageDealt, color: 'red' }); // 공격자 ID 포함
                 }
 
+                this.eventManager.emit(GAME_EVENTS.DAMAGE_CALCULATED, {
+                    attackerId: attackerId,
+                    targetId: unitId,
+                    hpDamageDealt,
+                    barrierDamageDealt,
+                    newHp: unitToUpdate.currentHp
+                });
+
                 if (unitToUpdate.currentHp <= 0) {
                     this.eventManager.emit(GAME_EVENTS.UNIT_DEATH, { unitId: unitId, unitName: unitToUpdate.name, unitType: unitToUpdate.type });
                     console.log(`[BattleCalculationManager] Unit '${unitId}' has died.`);

--- a/js/managers/PassiveSkillManager.js
+++ b/js/managers/PassiveSkillManager.js
@@ -23,18 +23,19 @@ export class PassiveSkillManager {
     }
 
     _setupEventListeners() {
-        // \uD83D\uDCA1 \uBCC0\uACBD\uC810: 'UNIT_ATTACK_ATTEMPT' \uB300\uC2E0 'BASIC_ATTACK_LANDED'\uB97C \uAD6C\uB3C4\uD569\uB2C8\uB2E4.
-        // \uC774\uC81C "\uD3C9\uD0C0 \uC2EC\uD310"\uC758 \uD310\uC815\uC774 \uB05D\uB09C \uACF5\uACA9\uC5D0 \uB300\uD574\uC11C\uB9CC \uBC18\uC751\uD569\uB2C8\uB2E4.
-        this.eventManager.subscribe(GAME_EVENTS.BASIC_ATTACK_LANDED, this._onUnitAttackAttempt.bind(this));
+        // \uD83D\uDCA1 \uBCC0\uACBD\uC810: \uACF5\uACA9 \uD53C\uD574 \uACC4\uC0B0\uC774 \uB9CC\uB4E0 \uD6C4 \uD589\uB3D9\uD558\uB294 \uD504\uB85C\uC138\uC2A4\uB294
+        // 'DAMAGE_CALCULATED' \uC774\uBCA4\uD2B8\uB97C \uCC38\uC870\uD569\uB2C8\uB2E4.
+        this.eventManager.subscribe(GAME_EVENTS.DAMAGE_CALCULATED, this._onDamageCalculated.bind(this));
     }
 
     /**
-     * 유닛이 공격을 시도할 때 호출되어 '찢어발기기' 같은 스킬을 처리합니다.
-     * @param {{ attackerId: string, targetId: string }} data
+     * \uB370\uBBF8\uC9C0 \uACC4\uC0B0 \uD6C4 \uD638\uCD9C\uB418\uC5B4 \uB300\uC0C1\uC5D0\uAC8C \uC0C1\uD604\uC544\uC2DC\uB97C \uCC98\uB9AC\uD569\uB2C8\uB2E4.
+     * @param {{ attackerId: string, targetId: string, newHp: number }} data
      */
-    async _onUnitAttackAttempt({ attackerId, targetId }) {
+    async _onDamageCalculated({ attackerId, targetId, newHp }) {
         const attacker = this.battleSimulationManager.getUnitById(attackerId);
         if (!attacker || !attacker.skillSlots) return;
+        if (newHp !== undefined && newHp <= 0) return;
 
         const slotProb = [0.4, 0.3, 0.2];
 

--- a/js/managers/StatusEffectManager.js
+++ b/js/managers/StatusEffectManager.js
@@ -31,6 +31,11 @@ export class StatusEffectManager {
             this.applyEffect.bind(this)
         );
 
+        // \uC0AC\uB9DD \uC2DC \uBAA8\uB4E0 \uC0C1\uD604\uC544\uC2DC \uC81C\uAC70
+        this.eventManager.subscribe(GAME_EVENTS.UNIT_DEATH, ({ unitId }) => {
+            this.clearAllEffectsOfUnit(unitId);
+        });
+
         this.eventManager.subscribe(GAME_EVENTS.UNIT_TURN_START, ({ unitId }) => { // ✨ 상수 사용
             const active = this.turnCountManager.getEffectsOfUnit(unitId);
             if (active) {
@@ -121,5 +126,15 @@ export class StatusEffectManager {
                 delete this.activeTimedEffects[unitId];
             }
         }
+    }
+
+    /**
+     * 특정 유닛의 모든 상태 이상을 즉시 제거합니다.
+     * @param {string} unitId
+     */
+    clearAllEffectsOfUnit(unitId) {
+        this.turnCountManager.clearEffectsOfUnit(unitId);
+        delete this.activeTimedEffects[unitId];
+        if (GAME_DEBUG_MODE) console.log(`[StatusEffectManager] Cleared all status effects from unit ${unitId}.`);
     }
 }

--- a/js/managers/TurnCountManager.js
+++ b/js/managers/TurnCountManager.js
@@ -83,6 +83,17 @@ export class TurnCountManager {
     }
 
     /**
+     * 특정 유닛의 모든 지속 효과를 제거합니다.
+     * @param {string} unitId
+     */
+    clearEffectsOfUnit(unitId) {
+        if (this.activeEffects.has(unitId)) {
+            this.activeEffects.delete(unitId);
+            console.log(`[TurnCountManager] All effects removed from unit '${unitId}'.`);
+        }
+    }
+
+    /**
      * 모든 유닛의 모든 지속 효과를 초기화합니다.
      */
     clearAllEffects() {


### PR DESCRIPTION
## Summary
- trigger passive status effects when `DAMAGE_CALCULATED` event fires
- do not apply passives if the target died
- emit `DAMAGE_CALCULATED` from `BattleCalculationManager`
- clear all effects on unit death

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a3a87e2d883278b2582da42832dc6