### PR TITLE
Add territory engine and UI managers

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -58,6 +58,11 @@ import { SynergyEngine } from './managers/SynergyEngine.js'; // ✨ SynergyEngin
 import { STATUS_EFFECTS } from '../data/statusEffects.js';
 
 import { TerritoryManager } from './managers/TerritoryManager.js';
+import { TerritoryEngine } from './managers/TerritoryEngine.js';
+import { TerritoryBackgroundManager } from './managers/TerritoryBackgroundManager.js';
+import { TerritoryGridManager } from './managers/TerritoryGridManager.js';
+import { TerritoryInputManager } from './managers/TerritoryInputManager.js';
+import { TerritorySceneManager } from './managers/TerritorySceneManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
 import { BattleGridManager } from './managers/BattleGridManager.js';
 import { CoordinateManager } from './managers/CoordinateManager.js';
@@ -272,7 +277,18 @@ export class GameEngine {
 
         this.layerEngine = new LayerEngine(this.renderer, this.cameraEngine);
 
-        this.territoryManager = new TerritoryManager();
+        this.territoryEngine = new TerritoryEngine();
+        this.territoryBackgroundManager = new TerritoryBackgroundManager(this.assetLoaderManager);
+        this.territoryGridManager = new TerritoryGridManager(this.measureManager);
+        this.territoryInputManager = new TerritoryInputManager(this.eventManager, this.territoryGridManager, this.renderer.canvas);
+        this.territorySceneManager = new TerritorySceneManager(this.sceneEngine);
+        this.territoryManager = new TerritoryManager(
+            this.assetLoaderManager,
+            this.measureManager,
+            this.eventManager,
+            this.sceneEngine,
+            this.renderer.canvas
+        );
         this.battleStageManager = new BattleStageManager(this.assetLoaderManager); // ✨ assetLoaderManager 전달
         this.battleGridManager = new BattleGridManager(this.measureManager, this.logicManager);
         // ✨ CoordinateManager 초기화 - BattleSimulationManager 후
@@ -591,7 +607,7 @@ export class GameEngine {
         this.gameLoop = new GameLoop(this._update, this._draw);
 
         // ✨ _initAsyncManagers에서 로드할 총 에셋 및 데이터 수를 수동으로 계산
-        const expectedDataAndAssetCount = 9 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 4; // 9(기존) + 6(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 4(전사 상태 스프라이트)
+        const expectedDataAndAssetCount = 10 + Object.keys(WARRIOR_SKILLS).length + 5 + 5 + 4; // 10(기존 + 영지 배경) + 6(워리어 스킬) + 5(기본 상태 아이콘) + 5(워리어 스킬 아이콘) + 4(전사 상태 스프라이트)
         this.assetLoaderManager.setTotalAssetsToLoad(expectedDataAndAssetCount);
 
         // 초기화 과정의 비동기 처리
@@ -709,6 +725,8 @@ export class GameEngine {
         await this.assetLoaderManager.loadImage('sprite_warrior_panel', 'assets/images/warrior-panel-1.png');
         // ✨ 전투 배경 이미지 로드
         await this.assetLoaderManager.loadImage('sprite_battle_stage_forest', 'assets/images/battle-stage-forest.png');
+        // ✨ 영지 배경 이미지 로드
+        await this.assetLoaderManager.loadImage('territory_background', 'assets/images/city-1.png');
 
         console.log(`[GameEngine] Registered unit ID: ${UNITS.WARRIOR.id}`);
         console.log(`[GameEngine] Loaded warrior sprite: ${UNITS.WARRIOR.spriteId}`);
@@ -924,4 +942,11 @@ export class GameEngine {
     getModifierLogManager() { return this.modifierLogManager; }
     // ✨ StackEngine getter 추가
     getStackEngine() { return this.stackEngine; }
+    // ✨ Territory 관련 매니저 getter 추가
+    getTerritoryEngine() { return this.territoryEngine; }
+    getTerritoryBackgroundManager() { return this.territoryBackgroundManager; }
+    getTerritoryGridManager() { return this.territoryGridManager; }
+    getTerritoryInputManager() { return this.territoryInputManager; }
+    getTerritorySceneManager() { return this.territorySceneManager; }
+    getTerritoryManager() { return this.territoryManager; }
 }

--- a/js/managers/TerritoryBackgroundManager.js
+++ b/js/managers/TerritoryBackgroundManager.js
@@ -1,0 +1,23 @@
+export class TerritoryBackgroundManager {
+    constructor(assetLoaderManager) {
+        console.log("\ud83c\udfde\ufe0f TerritoryBackgroundManager initialized. Managing the view of your lands.");
+        this.backgroundImage = assetLoaderManager.getImage('territory_background');
+        this.assetLoaderManager = assetLoaderManager;
+    }
+
+    draw(ctx) {
+        if (!this.backgroundImage) {
+            this.backgroundImage = this.assetLoaderManager.getImage('territory_background');
+        }
+
+        if (this.backgroundImage) {
+            const pixelRatio = window.devicePixelRatio || 1;
+            const logicalWidth = ctx.canvas.width / pixelRatio;
+            const logicalHeight = ctx.canvas.height / pixelRatio;
+            ctx.drawImage(this.backgroundImage, 0, 0, logicalWidth, logicalHeight);
+        } else {
+            ctx.fillStyle = 'black';
+            ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        }
+    }
+}

--- a/js/managers/TerritoryEngine.js
+++ b/js/managers/TerritoryEngine.js
@@ -1,0 +1,13 @@
+export class TerritoryEngine {
+    constructor() {
+        console.log("\ud83c\udfe0 TerritoryEngine initialized. The heart of your domain.");
+    }
+
+    update(deltaTime) {
+        // Placeholder for future territory logic updates
+    }
+
+    draw(ctx) {
+        // Drawing is delegated to specific managers like TerritoryBackgroundManager
+    }
+}

--- a/js/managers/TerritoryGridManager.js
+++ b/js/managers/TerritoryGridManager.js
@@ -1,0 +1,47 @@
+export class TerritoryGridManager {
+    constructor(measureManager) {
+        console.log("\u25a6 TerritoryGridManager initialized. Laying the foundations of your city.");
+        this.measureManager = measureManager;
+        this.gridRows = 2;
+        this.gridCols = 3;
+    }
+
+    getGridParameters() {
+        const canvasWidth = this.measureManager.get('gameResolution.width');
+        const canvasHeight = this.measureManager.get('gameResolution.height');
+        const tileSize = Math.min(
+            canvasWidth / (this.gridCols + 2),
+            canvasHeight / (this.gridRows + 2)
+        );
+        const totalWidth = tileSize * this.gridCols;
+        const totalHeight = tileSize * this.gridRows;
+        const offsetX = (canvasWidth - totalWidth) / 2;
+        const offsetY = (canvasHeight - totalHeight) / 2;
+        return { tileSize, offsetX, offsetY, totalWidth, totalHeight };
+    }
+
+    draw(ctx) {
+        const { tileSize, offsetX, offsetY, totalWidth, totalHeight } = this.getGridParameters();
+
+        ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+        ctx.lineWidth = 1;
+
+        // vertical lines
+        for (let i = 0; i <= this.gridCols; i++) {
+            const x = offsetX + i * tileSize;
+            ctx.beginPath();
+            ctx.moveTo(x, offsetY);
+            ctx.lineTo(x, offsetY + totalHeight);
+            ctx.stroke();
+        }
+
+        // horizontal lines
+        for (let i = 0; i <= this.gridRows; i++) {
+            const y = offsetY + i * tileSize;
+            ctx.beginPath();
+            ctx.moveTo(offsetX, y);
+            ctx.lineTo(offsetX + totalWidth, y);
+            ctx.stroke();
+        }
+    }
+}

--- a/js/managers/TerritoryInputManager.js
+++ b/js/managers/TerritoryInputManager.js
@@ -1,0 +1,33 @@
+export class TerritoryInputManager {
+    constructor(eventManager, territoryGridManager, canvas) {
+        console.log("\ud83d\udcbb TerritoryInputManager initialized. Awaiting your command.");
+        this.eventManager = eventManager;
+        this.territoryGridManager = territoryGridManager;
+        this.canvas = canvas;
+        if (this.canvas) {
+            this.canvas.addEventListener('click', (e) => this._onClick(e));
+        }
+        this.onTileClick = null;
+    }
+
+    _onClick(e) {
+        const rect = this.canvas.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        this.handleGridClick(x, y);
+    }
+
+    handleGridClick(mouseX, mouseY) {
+        const { tileSize, offsetX, offsetY, totalWidth, totalHeight } = this.territoryGridManager.getGridParameters();
+        if (mouseX < offsetX || mouseX > offsetX + totalWidth || mouseY < offsetY || mouseY > offsetY + totalHeight) {
+            return;
+        }
+        const col = Math.floor((mouseX - offsetX) / tileSize);
+        const row = Math.floor((mouseY - offsetY) / tileSize);
+        const tileId = row * this.territoryGridManager.gridCols + col;
+        console.log(`[TerritoryInputManager] Tile clicked: ${tileId}`);
+        if (typeof this.onTileClick === 'function') {
+            this.onTileClick(tileId);
+        }
+    }
+}

--- a/js/managers/TerritoryManager.js
+++ b/js/managers/TerritoryManager.js
@@ -1,28 +1,27 @@
 // js/managers/TerritoryManager.js
+import { TerritoryEngine } from './TerritoryEngine.js';
+import { TerritoryBackgroundManager } from './TerritoryBackgroundManager.js';
+import { TerritoryGridManager } from './TerritoryGridManager.js';
+import { TerritoryInputManager } from './TerritoryInputManager.js';
+import { TerritorySceneManager } from './TerritorySceneManager.js';
 
 export class TerritoryManager {
-    constructor() {
+    constructor(assetLoaderManager, measureManager, eventManager, sceneEngine, canvas) {
         console.log("\ud83c\udf33 TerritoryManager initialized. Ready to oversee the domain. \ud83c\udf33");
+        this.engine = new TerritoryEngine();
+        this.backgroundManager = new TerritoryBackgroundManager(assetLoaderManager);
+        this.gridManager = new TerritoryGridManager(measureManager);
+        this.sceneManager = new TerritorySceneManager(sceneEngine);
+        this.inputManager = new TerritoryInputManager(eventManager, this.gridManager, canvas);
+        this.inputManager.onTileClick = (tileId) => this.sceneManager.switchToScene(tileId);
+    }
+
+    update(deltaTime) {
+        this.engine.update(deltaTime);
     }
 
     draw(ctx) {
-        // 경로의 css 크기를 기본으로 그림을 진행
-        // Renderer 에서 pixelRatio 를 적용하면서 canvas.width/그 포로는 무리적 크기를 반환하고 있으므로
-        // draw 방법에서는 css 크기를 사용하는 것이 맞다.
-        const pixelRatio = window.devicePixelRatio || 1;
-        const logicalWidth = ctx.canvas.width / pixelRatio;
-        const logicalHeight = ctx.canvas.height / pixelRatio;
-
-        ctx.fillStyle = '#4CAF50';
-        ctx.fillRect(0, 0, logicalWidth, logicalHeight);
-
-        ctx.fillStyle = 'white';
-        ctx.font = '60px Arial';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText('나의 영지', logicalWidth / 2, logicalHeight / 2 - 50);
-
-        ctx.font = '24px Arial';
-        ctx.fillText('영지에서 모험을 준비하세요!', logicalWidth / 2, logicalHeight / 2 + 30);
+        this.backgroundManager.draw(ctx);
+        this.gridManager.draw(ctx);
     }
 }

--- a/js/managers/TerritorySceneManager.js
+++ b/js/managers/TerritorySceneManager.js
@@ -1,0 +1,12 @@
+export class TerritorySceneManager {
+    constructor(sceneEngine) {
+        console.log("\ud83c\udfae TerritorySceneManager initialized. Preparing scenes for your adventures.");
+        this.sceneEngine = sceneEngine;
+    }
+
+    switchToScene(tileId) {
+        console.log(`[TerritorySceneManager] Switching to scene for tile ${tileId}`);
+        // Future: map tileId to scene names
+        // this.sceneEngine.setCurrentScene(sceneName);
+    }
+}


### PR DESCRIPTION
## Summary
- overhaul territory screen by creating TerritoryEngine and managers
- load city-1.png as territory background
- draw new grid and handle input via dedicated managers
- integrate territory managers into GameEngine initialization

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a41b58fc48327ae4e8d9270533206