### PR TITLE
Add Territory UI manager with tavern tooltip

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -61,6 +61,7 @@ import { TerritoryEngine } from './managers/TerritoryEngine.js';
 import { TerritoryBackgroundManager } from './managers/TerritoryBackgroundManager.js';
 import { TerritoryGridManager } from './managers/TerritoryGridManager.js';
 import { TerritoryInputManager } from './managers/TerritoryInputManager.js';
+import { TerritoryUIManager } from './managers/TerritoryUIManager.js';
 import { TerritorySceneManager } from './managers/TerritorySceneManager.js';
 import { BattleStageManager } from './managers/BattleStageManager.js';
 import { BattleGridManager } from './managers/BattleGridManager.js';
@@ -279,10 +280,11 @@ export class GameEngine {
         this.territoryEngine = new TerritoryEngine();
         this.territoryBackgroundManager = new TerritoryBackgroundManager(this.assetLoaderManager);
         this.territoryGridManager = new TerritoryGridManager(this.measureManager);
+        this.territoryUIManager = new TerritoryUIManager();
         this.territoryInputManager = new TerritoryInputManager(
-            this.eventManager,
+            this.renderer.canvas,
             this.territoryGridManager,
-            this.renderer.canvas
+            this.territoryUIManager
         );
         this.territorySceneManager = new TerritorySceneManager(this.sceneEngine);
         this.battleStageManager = new BattleStageManager(this.assetLoaderManager); // ✨ assetLoaderManager 전달
@@ -562,7 +564,8 @@ export class GameEngine {
         this.sceneEngine.registerScene(UI_STATES.MAP_SCREEN, [
             this.territoryBackgroundManager,
             this.territoryGridManager,
-            this.territoryEngine
+            this.territoryEngine,
+            this.territoryUIManager
         ]);
         this.sceneEngine.registerScene(UI_STATES.COMBAT_SCREEN, [
             this.battleStageManager,    // 배경 그리기
@@ -727,6 +730,7 @@ export class GameEngine {
         await this.assetLoaderManager.loadImage('sprite_battle_stage_forest', 'assets/images/battle-stage-forest.png');
         // ✨ 영지 배경 이미지 로드
         await this.assetLoaderManager.loadImage('territory_background', 'assets/images/city-1.png');
+        await this.assetLoaderManager.loadImage('tavern-icon', 'assets/territory/tavern-icon.png');
 
         console.log(`[GameEngine] Registered unit ID: ${UNITS.WARRIOR.id}`);
         console.log(`[GameEngine] Loaded warrior sprite: ${UNITS.WARRIOR.spriteId}`);
@@ -947,5 +951,7 @@ export class GameEngine {
     getTerritoryBackgroundManager() { return this.territoryBackgroundManager; }
     getTerritoryGridManager() { return this.territoryGridManager; }
     getTerritoryInputManager() { return this.territoryInputManager; }
+    getTerritoryUIManager() { return this.territoryUIManager; }
     getTerritorySceneManager() { return this.territorySceneManager; }
 }
+

--- a/js/managers/TerritoryGridManager.js
+++ b/js/managers/TerritoryGridManager.js
@@ -1,52 +1,76 @@
-/**
- * Manages the placement grid for the territory screen.
- * Currently renders a simple 3x2 layout of slots.
- */
 export class TerritoryGridManager {
     constructor(measureManager) {
         console.log("▦ TerritoryGridManager initialized. Laying the foundations of your city.");
         this.measureManager = measureManager;
         this.gridRows = 2;
         this.gridCols = 3;
-        // tile size calculations can be updated via measureManager
+        this.grid = this.createGridData();
     }
 
-    draw(ctx) {
-        const { tileSize, offsetX, offsetY, totalWidth, totalHeight } = this.getGridParameters();
-
-        ctx.strokeStyle = 'rgba(255,255,255,0.5)';
-        ctx.lineWidth = 1;
-
-        // vertical lines
-        for (let i = 0; i <= this.gridCols; i++) {
-            const x = offsetX + i * tileSize;
-            ctx.beginPath();
-            ctx.moveTo(x, offsetY);
-            ctx.lineTo(x, offsetY + totalHeight);
-            ctx.stroke();
+    createGridData() {
+        const grid = [];
+        for (let i = 0; i < this.gridRows; i++) {
+            grid.push(Array(this.gridCols).fill(null));
         }
+        grid[0][0] = { type: 'building', id: 'tavern', icon: 'tavern-icon' };
+        return grid;
+    }
 
-        // horizontal lines
-        for (let i = 0; i <= this.gridRows; i++) {
-            const y = offsetY + i * tileSize;
-            ctx.beginPath();
-            ctx.moveTo(offsetX, y);
-            ctx.lineTo(offsetX + totalWidth, y);
-            ctx.stroke();
+    getGridCellBounds(row, col, canvasWidth, canvasHeight) {
+        const gridAreaWidth = canvasWidth * 0.8;
+        const gridAreaHeight = canvasHeight * 0.8;
+        const offsetX = (canvasWidth - gridAreaWidth) / 2;
+        const offsetY = (canvasHeight - gridAreaHeight) / 2;
+        const cellWidth = gridAreaWidth / this.gridCols;
+        const cellHeight = gridAreaHeight / this.gridRows;
+
+        const x = offsetX + col * cellWidth;
+        const y = offsetY + row * cellHeight;
+        return { x, y, width: cellWidth, height: cellHeight };
+    }
+
+    getCellAtPosition(x, y, canvasWidth, canvasHeight) {
+        const gridAreaWidth = canvasWidth * 0.8;
+        const gridAreaHeight = canvasHeight * 0.8;
+        const offsetX = (canvasWidth - gridAreaWidth) / 2;
+        const offsetY = (canvasHeight - gridAreaHeight) / 2;
+        const cellWidth = gridAreaWidth / this.gridCols;
+        const cellHeight = gridAreaHeight / this.gridRows;
+
+        if (x >= offsetX && x < offsetX + gridAreaWidth && y >= offsetY && y < offsetY + gridAreaHeight) {
+            const col = Math.floor((x - offsetX) / cellWidth);
+            const row = Math.floor((y - offsetY) / cellHeight);
+            return { row, col };
+        }
+        return null;
+    }
+
+    draw(ctx, canvasWidth, canvasHeight, assetLoaderManager) {
+        for (let i = 0; i < this.gridRows; i++) {
+            for (let j = 0; j < this.gridCols; j++) {
+                const bounds = this.getGridCellBounds(i, j, canvasWidth, canvasHeight);
+                ctx.strokeStyle = 'rgba(255, 255, 255, 0.2)';
+                ctx.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
+
+                const cellData = this.grid[i][j];
+                if (cellData && cellData.icon) {
+                    const icon = assetLoaderManager.getImage(cellData.icon);
+                    if (icon) {
+                        const iconX = bounds.x + (bounds.width - icon.width) / 2;
+                        const iconY = bounds.y + (bounds.height - icon.height) / 2;
+                        ctx.drawImage(icon, iconX, iconY);
+                    }
+                }
+            }
         }
     }
 
-    getGridParameters() {
-        const canvasWidth = this.measureManager.get('gameResolution.width');
-        const canvasHeight = this.measureManager.get('gameResolution.height');
-        const tileSize = Math.min(
-            canvasWidth / (this.gridCols + 2),
-            canvasHeight / (this.gridRows + 2)
-        );
-        const totalWidth = tileSize * this.gridCols;
-        const totalHeight = tileSize * this.gridRows;
-        const offsetX = (canvasWidth - totalWidth) / 2;
-        const offsetY = (canvasHeight - totalHeight) / 2;
-        return { tileSize, offsetX, offsetY, totalWidth, totalHeight };
+    getTavernPosition(canvasWidth, canvasHeight) {
+        const bounds = this.getGridCellBounds(0, 0, canvasWidth, canvasHeight);
+        return { x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height };
+    }
+
+    getBuildingAt(row, col) {
+        return this.grid?.[row]?.[col];
     }
 }

--- a/js/managers/TerritoryInputManager.js
+++ b/js/managers/TerritoryInputManager.js
@@ -1,37 +1,54 @@
-/**
- * Handles player input on the territory screen.
- * For now it simply converts canvas clicks into grid coordinates.
- */
 export class TerritoryInputManager {
-    constructor(eventManager, territoryGridManager, canvas) {
+    constructor(canvas, territoryGridManager, territoryUIManager) {
         console.log("🖱️ TerritoryInputManager initialized. Awaiting your command.");
-        this.eventManager = eventManager;
-        this.territoryGridManager = territoryGridManager;
         this.canvas = canvas;
+        this.territoryGridManager = territoryGridManager;
+        this.territoryUIManager = territoryUIManager;
+        this.hoveredTile = null;
+
         if (this.canvas) {
-            this.canvas.addEventListener('click', (e) => this._onClick(e));
+            this.canvas.addEventListener('mousemove', (event) => {
+                const rect = this.canvas.getBoundingClientRect();
+                const mouseX = event.clientX - rect.left;
+                const mouseY = event.clientY - rect.top;
+                this.handleMouseMove(mouseX, mouseY, this.canvas.width, this.canvas.height);
+            });
+
+            this.canvas.addEventListener('mousedown', (event) => {
+                const rect = this.canvas.getBoundingClientRect();
+                const mouseX = event.clientX - rect.left;
+                const mouseY = event.clientY - rect.top;
+                this.handleMouseClick(mouseX, mouseY, this.canvas.width, this.canvas.height);
+            });
         }
-        this.onTileClick = null;
     }
 
-    _onClick(e) {
-        const rect = this.canvas.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const y = e.clientY - rect.top;
-        this.handleGridClick(x, y);
+    handleMouseClick(mouseX, mouseY, canvasWidth, canvasHeight) {
+        const clickedCell = this.territoryGridManager.getCellAtPosition(mouseX, mouseY, canvasWidth, canvasHeight);
+        if (clickedCell && this.territoryGridManager.getBuildingAt(clickedCell.row, clickedCell.col)?.id === 'tavern') {
+            console.log("여관 타일 클릭!");
+            // 여관 클릭 시 로직 (추후 구현)
+        }
     }
 
-    handleGridClick(mouseX, mouseY) {
-        const { tileSize, offsetX, offsetY, totalWidth, totalHeight } = this.territoryGridManager.getGridParameters();
-        if (mouseX < offsetX || mouseX > offsetX + totalWidth || mouseY < offsetY || mouseY > offsetY + totalHeight) {
-            return;
-        }
-        const col = Math.floor((mouseX - offsetX) / tileSize);
-        const row = Math.floor((mouseY - offsetY) / tileSize);
-        const tileId = row * this.territoryGridManager.gridCols + col;
-        console.log(`[TerritoryInputManager] Tile clicked: ${tileId}`);
-        if (typeof this.onTileClick === 'function') {
-            this.onTileClick(tileId);
+    handleMouseMove(mouseX, mouseY, canvasWidth, canvasHeight) {
+        const hoveredCell = this.territoryGridManager.getCellAtPosition(mouseX, mouseY, canvasWidth, canvasHeight);
+        if (hoveredCell) {
+            const building = this.territoryGridManager.getBuildingAt(hoveredCell.row, hoveredCell.col);
+            if (building?.id === 'tavern') {
+                this.hoveredTile = { row: hoveredCell.row, col: hoveredCell.col };
+                this.territoryUIManager.showTooltip('여관', mouseX, mouseY);
+                this.territoryUIManager.animateIcon('tavern-icon');
+            } else {
+                this.hoveredTile = null;
+                this.territoryUIManager.hideTooltip();
+                this.territoryUIManager.stopAnimation('tavern-icon');
+            }
+        } else {
+            this.hoveredTile = null;
+            this.territoryUIManager.hideTooltip();
+            this.territoryUIManager.stopAnimation('tavern-icon');
         }
     }
 }
+

--- a/js/managers/TerritoryUIManager.js
+++ b/js/managers/TerritoryUIManager.js
@@ -1,0 +1,67 @@
+export class TerritoryUIManager {
+    constructor() {
+        console.log("🖼️ TerritoryUIManager initialized. Managing the visual aspects of your territory.");
+        this.tooltipElement = this.createTooltipElement();
+        document.body.appendChild(this.tooltipElement);
+        this.tooltipElement.style.display = 'none';
+        this.animatedIcon = null;
+        this.animationInterval = null;
+    }
+
+    createTooltipElement() {
+        const tooltip = document.createElement('div');
+        tooltip.style.position = 'absolute';
+        tooltip.style.backgroundColor = 'rgba(0, 0, 0, 0.8)';
+        tooltip.style.color = 'white';
+        tooltip.style.padding = '5px';
+        tooltip.style.borderRadius = '5px';
+        tooltip.style.fontSize = '12px';
+        tooltip.style.zIndex = '10';
+        return tooltip;
+    }
+
+    showTooltip(text, x, y) {
+        this.tooltipElement.textContent = text;
+        this.tooltipElement.style.left = `${x + 10}px`;
+        this.tooltipElement.style.top = `${y + 10}px`;
+        this.tooltipElement.style.display = 'block';
+    }
+
+    hideTooltip() {
+        this.tooltipElement.style.display = 'none';
+    }
+
+    animateIcon(iconKey) {
+        if (this.animatedIcon !== iconKey) {
+            this.stopAnimation(this.animatedIcon);
+            this.animatedIcon = iconKey;
+            let scale = 1;
+            let direction = 0.05;
+            this.animationInterval = setInterval(() => {
+                const iconElement = document.querySelector(`img.asset-${iconKey}`);
+                if (iconElement) {
+                    scale += direction;
+                    if (scale > 1.1 || scale < 1) {
+                        direction *= -1;
+                    }
+                    iconElement.style.transform = `scale(${scale})`;
+                }
+            }, 100);
+        }
+    }
+
+    stopAnimation(iconKey) {
+        if (this.animatedIcon === iconKey && this.animationInterval) {
+            clearInterval(this.animationInterval);
+            this.animatedIcon = null;
+            const iconElement = document.querySelector(`img.asset-${iconKey}`);
+            if (iconElement) {
+                iconElement.style.transform = `scale(1)`;
+            }
+        }
+    }
+
+    draw(ctx) {
+        // UI 요소 그리기 (툴팁은 HTML 요소로 처리하므로 canvas에 그리지 않음)
+    }
+}


### PR DESCRIPTION
## Summary
- enhance `TerritoryGridManager` with grid data and cell lookup
- track hover and clicks in `TerritoryInputManager`
- implement `TerritoryUIManager` for tooltips and simple icon animation
- integrate territory UI manager into `GameEngine`
- preload tavern icon asset

## Testing
- `npm test`
- `python3 -m http.server 8000` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a4aaf8ef883279b6888a6c6638dc4