### PR TITLE
Implement scene cleanup with EraserEngine

### DIFF
--- a/js/managers/BattleLogManager.js
+++ b/js/managers/BattleLogManager.js
@@ -92,6 +92,12 @@ export class BattleLogManager {
         console.log(`[BattleLog] ${message}`);
     }
 
+    clearLog() {
+        this.logMessages = [];
+        this.draw(this.ctx);
+        console.log("[BattleLogManager] Log messages cleared.");
+    }
+
     draw(ctx) {
         ctx.clearRect(0, 0, this.canvas.width / this.pixelRatio, this.canvas.height / this.pixelRatio);
         ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';

--- a/js/managers/BattleSimulationManager.js
+++ b/js/managers/BattleSimulationManager.js
@@ -150,6 +150,11 @@ export class BattleSimulationManager {
         };
     }
 
+    clearBattleState() {
+        this.unitsOnGrid = [];
+        console.log("[BattleSimulationManager] All units removed from the grid.");
+    }
+
     /**
      * 배틀 그리드에 배치된 모든 유닛을 그립니다.
      * @param {CanvasRenderingContext2D} ctx

--- a/js/managers/EraserEngine.js
+++ b/js/managers/EraserEngine.js
@@ -1,0 +1,33 @@
+// js/managers/EraserEngine.js
+
+/**
+ * \uc2fc\uc774 \uc885\ub8cc\ub420 \ub54c \uc0ac\uc6a9\ub41c \uc694\uc57d\ud55c \ucee8\ud37c\ub7f0\ud2b8\ub97c \uc2dc\uc791\ub9cc \ubc1b\uc544 \ucc98\ub9ac\ud558\ub294 \uc5f0\uae30\ub97c \uc9c4\ud589\ud569\ub2c8\ub2e4.
+ */
+export class EraserEngine {
+    constructor() {
+        console.log("\uD83D\uDDD1\uFE0F EraserEngine initialized. Ready to clean up scenes.");
+        this.cleanupTasks = new Map();
+    }
+
+    /**
+     * \ud2b8\ub9ac\uadf8\ub7a8 \uc885\ub8cc \uc2dc \ubc1c\ud560 \uc9c4\ud589 \uc791\uc5c5\uc744 \ub4f1\ub85d\ud569\ub2c8\ub2e4.
+     * @param {string} sceneName
+     * @param {Function} task
+     */
+    registerCleanupTask(sceneName, task) {
+        this.cleanupTasks.set(sceneName, task);
+        console.log(`[EraserEngine] Cleanup task registered for scene: ${sceneName}`);
+    }
+
+    /**
+     * \uc9c4\ud589 \uc791\uc5c5\uc744 \uc2e4\ud589\ud569\ub2c8\ub2e4.
+     * @param {string} sceneName
+     */
+    cleanupScene(sceneName) {
+        if (this.cleanupTasks.has(sceneName)) {
+            console.log(`[EraserEngine] Cleaning up scene: ${sceneName}...`);
+            const task = this.cleanupTasks.get(sceneName);
+            task();
+        }
+    }
+}

--- a/js/managers/SceneEngine.js
+++ b/js/managers/SceneEngine.js
@@ -1,10 +1,11 @@
 // js/managers/SceneEngine.js
 
 export class SceneEngine {
-    constructor() {
+    constructor(eraserEngine = null) {
         console.log("\uD83C\uDFAC SceneEngine initialized. Ready to manage game scenes. \uD83C\uDFAC");
         this.scenes = new Map();
         this.currentSceneName = null;
+        this.eraserEngine = eraserEngine;
     }
 
     /**
@@ -23,6 +24,9 @@ export class SceneEngine {
      */
     setCurrentScene(sceneName) {
         if (this.scenes.has(sceneName)) {
+            if (this.currentSceneName && this.eraserEngine) {
+                this.eraserEngine.cleanupScene(this.currentSceneName);
+            }
             this.currentSceneName = sceneName;
             console.log(`[SceneEngine] Current scene set to: ${sceneName}`);
         } else {

--- a/js/managers/TerritoryBackgroundManager.js
+++ b/js/managers/TerritoryBackgroundManager.js
@@ -5,8 +5,8 @@
 export class TerritoryBackgroundManager {
     constructor(assetLoaderManager) {
         console.log("🖼️ TerritoryBackgroundManager initialized. Managing the view of your lands.");
-        // Grab the preloaded image from the asset loader
-        this.backgroundImage = assetLoaderManager.getImage('territory_background');
+        this.assetLoaderManager = assetLoaderManager;
+        this.backgroundImage = null;
     }
 
     draw(ctx) {
@@ -14,6 +14,9 @@ export class TerritoryBackgroundManager {
         const logicalWidth = ctx.canvas.width / pixelRatio;
         const logicalHeight = ctx.canvas.height / pixelRatio;
 
+        if (!this.backgroundImage && this.assetLoaderManager) {
+            this.backgroundImage = this.assetLoaderManager.getImage('territory_background');
+        }
         if (this.backgroundImage) {
             // Fit the background image to the canvas
             ctx.drawImage(this.backgroundImage, 0, 0, logicalWidth, logicalHeight);

--- a/js/managers/TerritoryGridManager.js
+++ b/js/managers/TerritoryGridManager.js
@@ -1,7 +1,8 @@
 export class TerritoryGridManager {
-    constructor(measureManager) {
+    constructor(measureManager, assetLoaderManager) {
         console.log("▦ TerritoryGridManager initialized. Laying the foundations of your city.");
         this.measureManager = measureManager;
+        this.assetLoaderManager = assetLoaderManager;
         this.gridRows = 2;
         this.gridCols = 3;
         this.grid = this.createGridData();
@@ -45,7 +46,8 @@ export class TerritoryGridManager {
         return null;
     }
 
-    draw(ctx, canvasWidth, canvasHeight, assetLoaderManager) {
+    draw(ctx, canvasWidth, canvasHeight) {
+        const loader = this.assetLoaderManager;
         for (let i = 0; i < this.gridRows; i++) {
             for (let j = 0; j < this.gridCols; j++) {
                 const bounds = this.getGridCellBounds(i, j, canvasWidth, canvasHeight);
@@ -54,7 +56,7 @@ export class TerritoryGridManager {
 
                 const cellData = this.grid[i][j];
                 if (cellData && cellData.icon) {
-                    const icon = assetLoaderManager.getImage(cellData.icon);
+                    const icon = loader?.getImage(cellData.icon);
                     if (icon) {
                         const iconX = bounds.x + (bounds.width - icon.width) / 2;
                         const iconY = bounds.y + (bounds.height - icon.height) / 2;

--- a/js/managers/TerritoryUIManager.js
+++ b/js/managers/TerritoryUIManager.js
@@ -61,6 +61,12 @@ export class TerritoryUIManager {
         }
     }
 
+    cleanup() {
+        this.hideTooltip();
+        this.stopAnimation(this.animatedIcon);
+        console.log("[TerritoryUIManager] Cleaned up UI elements for scene transition.");
+    }
+
     draw(ctx) {
         // UI 요소 그리기 (툴팁은 HTML 요소로 처리하므로 canvas에 그리지 않음)
     }

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -230,6 +230,14 @@ export class VFXManager {
         }
     }
 
+    clearEffects() {
+        this.activeDamageNumbers = [];
+        this.activeSkillNames = [];
+        this.activeWeaponDrops.clear();
+        this.bleedingUnits.clear();
+        if (GAME_DEBUG_MODE) console.log("[VFXManager] All active visual effects cleared.");
+    }
+
     /**
      * 특정 유닛의 HP 바를 그립니다.
      * 실제 그리기 위치는 AnimationManager로 계산된 값을 사용합니다.


### PR DESCRIPTION
## Summary
- add `EraserEngine` for scene cleanup tasks
- invoke cleanup from `SceneEngine` when scenes switch
- integrate eraser with `GameEngine` and register tasks for combat and map scenes
- add cleanup methods to managers (`BattleSimulationManager`, `BattleLogManager`, `VFXManager`, `TerritoryUIManager`)
- fix territory asset loading by injecting `AssetLoaderManager`

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687a4cb7050083278d9be75a4d7bd81d