### PR TITLE
Fix missing battle transition accessor

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -895,6 +895,7 @@ export class GameEngine {
     getMercenaryPanelManager() { return this.mercenaryPanelManager; }
     getPanelEngine() { return this.panelEngine; }
     getBattleLogManager() { return this.battleLogManager; }
+    getVFXManager() { return this.vfxManager; }
     getBindingManager() { return this.bindingManager; }
 
     // 새로운 엔진들에 대한 getter 메서드


### PR DESCRIPTION
## Summary
- expose the VFX manager via a getter so `HideAndSeekManager` doesn't crash when changing scenes
- keep the territory grid unobtrusive by reverting the stroke opacity

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687a554407f88327bf5ed8a135245d45