### PR TITLE
Fix double attack after buff skills

### DIFF
--- a/js/managers/ClassAIManager.js
+++ b/js/managers/ClassAIManager.js
@@ -56,8 +56,12 @@ export class ClassAIManager {
             buffAction.followUp = subsequentAction;
             return buffAction;
         }
+
         if (buffAction) {
-            if (!subsequentAction) {
+            if (
+                !subsequentAction &&
+                !(activatedBuff.effect && activatedBuff.effect.allowAdditionalAttack)
+            ) {
                 buffAction.followUp = this.basicAIManager.determineMoveAndTarget(
                     unit,
                     allUnits,


### PR DESCRIPTION
## Summary
- avoid chaining basic attack after a buff skill that already grants an extra attack
- ensure debug.html loads without errors

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687a596d81b0832781d6facae292b4f6