### PR TITLE
Enable async initialization for GameEngine

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -208,11 +208,12 @@
     // ✨ 상수 파일 임포트
     import { BUTTON_IDS } from './js/constants.js';
 
-        document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('DOMContentLoaded', async () => {
             let gameEngine; // gameEngine 인스턴스를 스코프 밖으로 뺍니다.
 
             try {
                 gameEngine = new GameEngine('gameCanvas'); // GameEngine 인스턴스 생성
+                await gameEngine.init(); // 비동기 초기화 완료 대기
                 gameEngine.eventManager.setGameRunningState(true); // ✨ 디버그 모드에서도 게임 시작 시 상태 설정
                 gameEngine.start(); // 게임 엔진 시작
             } catch (error) {

--- a/js/main.js
+++ b/js/main.js
@@ -2,15 +2,19 @@
 import { GameEngine } from './GameEngine.js';
 // ✨ 상수 파일 임포트
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     try {
         const gameEngine = new GameEngine('gameCanvas');
-        gameEngine.eventManager.setGameRunningState(true); // ✨ 게임 시작 시 상태 설정
+
+        // ✨ gameEngine의 비동기 초기화가 끝날 때까지 기다립니다.
+        await gameEngine.init();
+
+        gameEngine.eventManager.setGameRunningState(true);
         gameEngine.start();
 
         // 버튼 리스너는 GameEngine에서 처리합니다.
     } catch (error) {
         console.error("Fatal Error: Game Engine failed to start.", error);
-        alert("\uAC8C\uC784 \uC2DC\uC791 \uC911 \uCE58\uBA85\uC801\uC778 \uC624\uB958\uAC00 \uBC1C\uC0DD\uD588\uC2B5\uB2C8\uB2E4. \uCF58\uC194\uC744 \uD655\uC778\uD574\uC8FC\uC138\uC694.");
+        alert("게임 시작 중 치명적인 오류가 발생했습니다. 콘솔을 확인해주세요.");
     }
 });


### PR DESCRIPTION
## Summary
- shift GameEngine asynchronous setup from constructor to new `init()` method
- call `init()` during DOMContentLoaded so the game waits for all async tasks before starting
- update debug page to also await `GameEngine.init()`

## Testing
- `npm test`
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`; `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687a5bb156fc8327a2cf4ce61d5102b6