### PR TITLE
Add layer camera usage and reorganize map layers

### DIFF
--- a/js/managers/LayerEngine.js
+++ b/js/managers/LayerEngine.js
@@ -8,16 +8,17 @@ export class LayerEngine {
         this.layers = [];
     }
 
-    registerLayer(name, drawFunction, zIndex) {
+    // 'useCamera' determines whether camera transformations are applied when drawing this layer
+    registerLayer(name, drawFunction, zIndex, useCamera = false) {
         const existingLayerIndex = this.layers.findIndex(layer => layer.name === name);
         if (existingLayerIndex !== -1) {
             console.warn(`[LayerEngine] Layer '${name}' already exists. Overwriting.`);
-            this.layers[existingLayerIndex] = { name, drawFunction, zIndex };
+            this.layers[existingLayerIndex] = { name, drawFunction, zIndex, useCamera };
         } else {
-            this.layers.push({ name, drawFunction, zIndex });
+            this.layers.push({ name, drawFunction, zIndex, useCamera });
         }
         this.layers.sort((a, b) => a.zIndex - b.zIndex);
-        console.log(`[LayerEngine] Registered layer: ${name} with zIndex: ${zIndex}`);
+        console.log(`[LayerEngine] Registered layer: ${name} with zIndex: ${zIndex}, useCamera: ${useCamera}`);
     }
 
     draw() {
@@ -27,7 +28,8 @@ export class LayerEngine {
         for (const layer of this.layers) {
             this.renderer.ctx.save();
 
-            if (layer.name === 'sceneLayer' && this.cameraEngine) {
+            // Apply camera transformations only if this layer opts in
+            if (layer.useCamera && this.cameraEngine) {
                 this.cameraEngine.applyTransform(this.renderer.ctx);
             }
 


### PR DESCRIPTION
## Summary
- allow layers to opt-in to camera transforms with `useCamera`
- restructure map and combat layer drawing order
- draw status and passive icons on a dedicated layer

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a629209a8832794247f26b8701c2b