### PR TITLE
Implement DOMEngine to handle HTML UI

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -141,6 +141,7 @@
     <div id="gameContainer">
         <canvas id="gameCanvas"></canvas>
         <canvas id="combatLogCanvas"></canvas>
+        <img src="assets/territory/tavern-icon.png" id="tavern-icon-btn" alt="여관 아이콘">
     </div>
     <!-- ✨ 전투 시작을 위한 별도의 HTML 버튼 -->
     <button id="battleStartHtmlBtn" class="game-button">전투 시작</button>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div id="gameContainer">
         <canvas id="gameCanvas"></canvas>
         <canvas id="combatLogCanvas"></canvas>
+        <img src="assets/territory/tavern-icon.png" id="tavern-icon-btn" alt="여관 아이콘">
     </div>
     <button id="toggleHeroPanelBtn" style="position: absolute; top: 10px; right: 10px; z-index: 100;">영웅 패널</button>
     <!-- ✨ 캔버스 버튼 외에 별도의 HTML 전투 시작 버튼 -->

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -96,6 +96,7 @@ import { OneTwoThreeManager } from './managers/OneTwoThreeManager.js';
 import { PassiveIsAlsoASkillManager } from './managers/PassiveIsAlsoASkillManager.js';
 import { ModifierEngine } from './managers/ModifierEngine.js';
 import { ModifierLogManager } from './managers/ModifierLogManager.js';
+import { DOMEngine } from './managers/DOMEngine.js'; // ✨ DOMEngine import
 // ✨ 상수 파일 임포트
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';
 
@@ -120,6 +121,9 @@ export class GameEngine {
         this.eventManager = new EventManager();
         // ✨ CRITICAL_ERROR 이벤트 구독
         this.eventManager.subscribe(GAME_EVENTS.CRITICAL_ERROR, this._handleCriticalError.bind(this));
+
+        // ✨ DOMEngine 초기화 (EventManager 이후)
+        this.domEngine = new DOMEngine(this.eventManager);
         // JudgementManager는 EventManager 이후 초기화
         this.judgementManager = new JudgementManager(this.eventManager);
 
@@ -698,6 +702,9 @@ export class GameEngine {
         if (GAME_DEBUG_MODE) console.log("\u2699\ufe0f GameEngine initialized successfully. \u2699\ufe0f");
 
         this._setupEventListeners();
+
+        // ✨ 게임 시작 시 DOM UI 초기 상태 설정
+        this.domEngine.updateUIForScene(UI_STATES.MAP_SCREEN);
     }
 
     /**
@@ -992,5 +999,6 @@ export class GameEngine {
     getTerritoryUIManager() { return this.territoryUIManager; }
     getTerritorySceneManager() { return this.territorySceneManager; }
     getHideAndSeekManager() { return this.hideAndSeekManager; }
+    getDOMEngine() { return this.domEngine; }
 }
 

--- a/js/managers/DOMEngine.js
+++ b/js/managers/DOMEngine.js
@@ -1,0 +1,57 @@
+import { GAME_EVENTS, UI_STATES } from '../constants.js';
+
+/**
+ * 게임의 모든 HTML DOM 요소를 관리하고 상호작용을 처리하는 엔진입니다.
+ * 캔버스와 독립적으로 UI를 제어합니다.
+ */
+export class DOMEngine {
+    constructor(eventManager) {
+        console.log('\ud83c\udfdb\ufe0f DOMEngine initialized. Managing all HTML UI elements.');
+        this.eventManager = eventManager;
+        this.elements = new Map();
+        this._registerElements();
+        this._setupEventListeners();
+    }
+
+    _registerElements() {
+        this.registerElement('tavern-icon-btn', document.getElementById('tavern-icon-btn'));
+    }
+
+    _setupEventListeners() {
+        const tavernIcon = this.getElement('tavern-icon-btn');
+        if (tavernIcon) {
+            tavernIcon.addEventListener('click', () => {
+                if (!tavernIcon.classList.contains('hidden')) {
+                    console.log('여관 아이콘(HTML 버튼)이 클릭되었습니다!');
+                    // 여관 패널 열기 등 추가 로직을 넣을 수 있습니다.
+                }
+            });
+        }
+
+        this.eventManager.subscribe(GAME_EVENTS.BATTLE_START, () => this.updateUIForScene(UI_STATES.COMBAT_SCREEN));
+        this.eventManager.subscribe(GAME_EVENTS.BATTLE_END, () => this.updateUIForScene(UI_STATES.MAP_SCREEN));
+    }
+
+    updateUIForScene(sceneName) {
+        console.log(`[DOMEngine] Updating UI for scene: ${sceneName}`);
+        const tavernIcon = this.getElement('tavern-icon-btn');
+        if (!tavernIcon) return;
+        if (sceneName === UI_STATES.MAP_SCREEN) {
+            tavernIcon.classList.remove('hidden');
+        } else {
+            tavernIcon.classList.add('hidden');
+        }
+    }
+
+    registerElement(id, element) {
+        if (!element) {
+            console.warn(`[DOMEngine] Element with ID '${id}' not found in the document.`);
+            return;
+        }
+        this.elements.set(id, element);
+    }
+
+    getElement(id) {
+        return this.elements.get(id);
+    }
+}

--- a/style.css
+++ b/style.css
@@ -65,3 +65,24 @@ canvas {
 .game-button:hover {
     background-color: #004d00;
 }
+
+/* \u2728 여관 아이콘 버튼 스타일 */
+#tavern-icon-btn {
+    position: absolute;
+    top: 25%;
+    left: 20%;
+    width: 128px;
+    height: 128px;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+    z-index: 10;
+}
+
+#tavern-icon-btn:hover {
+    transform: scale(1.1);
+}
+
+/* \u2728 요소를 숨기기 위한 헬퍼 클래스 */
+.hidden {
+    display: none !important;
+}


### PR DESCRIPTION
## Summary
- add `DOMEngine` manager for HTML interactions
- integrate `DOMEngine` with `GameEngine`
- add tavern icon element to `index.html` and `debug.html`
- style the tavern icon and add `.hidden` helper class

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687a67504a908327a8bfdb574317c3a4