### PR TITLE
Switch UI panels to DOM

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -62,9 +62,51 @@
             align-items: center;
         }
         /* #mercenaryPanelCanvas 스타일은 이제 필요 없습니다. */
-        #combatLogCanvas {
+        #battle-log-panel {
             margin-top: 10px;
             border: 2px solid #f00;
+            background-color: rgba(0,0,0,0.7);
+            color: white;
+            overflow-y: scroll;
+            padding: 10px;
+            width: 100%;
+            height: 15%;
+            box-sizing: border-box;
+        }
+        #hero-panel {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: 80vw;
+            height: 70vh;
+            background-color: rgba(26,26,26,0.9);
+            border: 2px solid #fff;
+            border-radius: 10px;
+            z-index: 50;
+            display: grid;
+            grid-template-columns: repeat(6, 1fr);
+            grid-template-rows: repeat(2, 1fr);
+            gap: 10px;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+        .hero-slot {
+            background-color: #333;
+            border: 1px solid #555;
+            border-radius: 5px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            padding: 5px;
+        }
+        .hero-slot img {
+            width: 70%;
+        }
+        .hidden {
+            display: none !important;
         }
     </style>
 </head>
@@ -139,9 +181,13 @@
         <button id="clearAllEffectsBtn">모든 효과 제거 (전체)</button>
     </div>
     <div id="gameContainer">
-        <canvas id="gameCanvas"></canvas>
-        <canvas id="combatLogCanvas"></canvas>
-        <img src="assets/territory/tavern-icon.png" id="tavern-icon-btn" alt="여관 아이콘">
+        <div id="territory-screen">
+            <div id="territory-grid"></div>
+            <img src="assets/territory/tavern-icon.png" id="tavern-icon-btn" alt="여관 아이콘">
+        </div>
+        <canvas id="gameCanvas" class="hidden"></canvas>
+        <div id="hero-panel" class="hidden"></div>
+        <div id="battle-log-panel" class="hidden"></div>
     </div>
     <!-- ✨ 전투 시작을 위한 별도의 HTML 버튼 -->
     <button id="battleStartHtmlBtn" class="game-button">전투 시작</button>
@@ -588,12 +634,6 @@
             const originalDraw = gameEngine._draw; // GameEngine의 원래 _draw 함수를 저장
             gameEngine._draw = function() { // GameEngine의 _draw를 오버라이드하여 FPS 로직 추가
                 originalDraw.apply(this, arguments); // 원래 _draw 함수 호출
-
-                // ✨ 전투 로그 패널 그리기 호출 추가
-                if (gameEngine.getPanelEngine()) {
-                    gameEngine.getPanelEngine().drawPanel('combatLog', gameEngine.getBattleLogManager().ctx);
-                }
-
                 // FPS 카운터 업데이트
                 frameCount++;
                 const currentTime = performance.now();

--- a/index.html
+++ b/index.html
@@ -8,9 +8,13 @@
 </head>
 <body>
     <div id="gameContainer">
-        <canvas id="gameCanvas"></canvas>
-        <canvas id="combatLogCanvas"></canvas>
-        <img src="assets/territory/tavern-icon.png" id="tavern-icon-btn" alt="여관 아이콘">
+        <div id="territory-screen">
+            <div id="territory-grid"></div>
+            <img src="assets/territory/tavern-icon.png" id="tavern-icon-btn" alt="여관 아이콘">
+        </div>
+        <canvas id="gameCanvas" class="hidden"></canvas>
+        <div id="hero-panel" class="hidden"></div>
+        <div id="battle-log-panel" class="hidden"></div>
     </div>
     <button id="toggleHeroPanelBtn" style="position: absolute; top: 10px; right: 10px; z-index: 100;">영웅 패널</button>
     <!-- ✨ 캔버스 버튼 외에 별도의 HTML 전투 시작 버튼 -->

--- a/js/managers/BattleLogManager.js
+++ b/js/managers/BattleLogManager.js
@@ -1,116 +1,58 @@
 // js/managers/BattleLogManager.js
 
-// ✨ 상수 파일 임포트
 import { GAME_EVENTS } from '../constants.js';
 
 export class BattleLogManager {
-    constructor(canvasElement, eventManager, measureManager) { // ✨ measureManager 추가
+    constructor(panelElement, eventManager, measureManager) {
         console.log("\uD83D\uDCDC BattleLogManager initialized. Ready to record battle events. \uD83D\uDCDC");
-        this.canvas = canvasElement;
-        this.ctx = this.canvas.getContext('2d');
+        this.panel = document.getElementById('battle-log-panel');
         this.eventManager = eventManager;
-        this.measureManager = measureManager; // ✨ measureManager 저장
-
-        this.pixelRatio = window.devicePixelRatio || 1;
-
+        this.measureManager = measureManager;
+        this.maxLogLines = 50;
         this.logMessages = [];
-        
-        // 초기 내부 해상도 설정 후 로그 치수 재계산
-        this.resizeCanvas();
-        this.recalculateLogDimensions();
-
-        // ✨ _setupEventListeners는 이제 GameEngine에서 명시적으로 호출됩니다.
-        // this._setupEventListeners();
     }
 
-    /**
-     * ✨ 로그 패널의 내부 치수를 재계산합니다.
-     * 이 메서드는 CompatibilityManager가 캔버스 크기를 조정한 후 호출해야 합니다.
-     */
     recalculateLogDimensions() {
-        const logicalCanvasHeight = this.measureManager.get('gameResolution.height');
-        this.padding = this.measureManager.get('combatLog.padding');
-        this.lineHeight = Math.floor(logicalCanvasHeight * this.measureManager.get('combatLog.lineHeightRatio'));
-        this.maxLogLines = Math.floor(((this.canvas.height / this.pixelRatio) - 2 * this.padding) / this.lineHeight);
-        
-        // 최대 줄 수를 초과하는 오래된 메시지 제거
-        while (this.logMessages.length > this.maxLogLines) {
-            this.logMessages.shift();
-        }
-        console.log(`[BattleLogManager] Log dimensions recalculated. Canvas size: ${this.canvas.width}x${this.canvas.height}, Max lines: ${this.maxLogLines}`);
-        this.resizeCanvas();
+        // DOM 기반 패널은 특별한 해상도 조정이 필요하지 않으므로 비워 둡니다.
     }
 
-    /**
-     * 캔버스 내부의 그리기 버퍼 해상도를 실제 표시 크기와 픽셀 비율에 맞춰 조정합니다.
-     */
-    resizeCanvas() {
-        const displayWidth = this.canvas.clientWidth;
-        const displayHeight = this.canvas.clientHeight;
-
-        if (this.canvas.width !== displayWidth * this.pixelRatio ||
-            this.canvas.height !== displayHeight * this.pixelRatio) {
-            this.canvas.width = displayWidth * this.pixelRatio;
-            this.canvas.height = displayHeight * this.pixelRatio;
-            this.ctx = this.canvas.getContext('2d');
-            this.ctx.scale(this.pixelRatio, this.pixelRatio);
-            console.log(`[BattleLogManager] Canvas internal resolution set to: ${this.canvas.width}x${this.canvas.height} (Display: ${displayWidth}x${displayHeight}, Ratio: ${this.pixelRatio})`);
-        }
-    }
-
-    /**
-     * ✨ 이벤트 리스너를 설정하는 메서드. 이제 GameEngine에서 명시적으로 호출됩니다.
-     */
     _setupEventListeners() {
-        // 전투 관련 이벤트를 구독하여 로그에 추가
-        this.eventManager.subscribe(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, (data) => { // ✨ 상수 사용
+        this.eventManager.subscribe(GAME_EVENTS.UNIT_ATTACK_ATTEMPT, (data) => {
             this.addLog(`${data.attackerId}가 ${data.targetId}를 공격 시도!`);
         });
-        this.eventManager.subscribe(GAME_EVENTS.DAMAGE_CALCULATED, (data) => { // ✨ 상수 사용
+        this.eventManager.subscribe(GAME_EVENTS.DAMAGE_CALCULATED, (data) => {
             this.addLog(`${data.unitId}가 ${data.hpDamageDealt + data.barrierDamageDealt} 피해를 입고 HP ${data.newHp}가 됨.`);
         });
-        this.eventManager.subscribe(GAME_EVENTS.UNIT_DEATH, (data) => { // ✨ 상수 사용
+        this.eventManager.subscribe(GAME_EVENTS.UNIT_DEATH, (data) => {
             this.addLog(`${data.unitName} (ID: ${data.unitId})이(가) 쓰러졌습니다!`);
         });
-        this.eventManager.subscribe(GAME_EVENTS.TURN_START, (data) => { // ✨ 상수 사용
+        this.eventManager.subscribe(GAME_EVENTS.TURN_START, (data) => {
             this.addLog(`--- 턴 ${data.turn} 시작 ---`);
         });
-        this.eventManager.subscribe(GAME_EVENTS.BATTLE_START, (data) => { // ✨ 상수 사용
+        this.eventManager.subscribe(GAME_EVENTS.BATTLE_START, (data) => {
             this.addLog(`[전투 시작] 맵: ${data.mapId}, 난이도: ${data.difficulty}`);
         });
-        this.eventManager.subscribe(GAME_EVENTS.BATTLE_END, (data) => { // ✨ 상수 사용
+        this.eventManager.subscribe(GAME_EVENTS.BATTLE_END, (data) => {
             this.addLog(`[전투 종료] 이유: ${data.reason}`);
         });
     }
 
     addLog(message) {
         const timestamp = new Date().toLocaleTimeString();
-        this.logMessages.push(`[${timestamp}] ${message}`);
-        if (this.logMessages.length > this.maxLogLines) {
-            this.logMessages.shift();
+        const entry = document.createElement('p');
+        entry.style.margin = '0 0 5px 0';
+        entry.textContent = `[${timestamp}] ${message}`;
+        this.panel.appendChild(entry);
+
+        if (this.panel.children.length > this.maxLogLines) {
+            this.panel.removeChild(this.panel.firstChild);
         }
+        this.panel.scrollTop = this.panel.scrollHeight;
         console.log(`[BattleLog] ${message}`);
     }
 
     clearLog() {
-        this.logMessages = [];
-        this.draw(this.ctx);
-        console.log("[BattleLogManager] Log messages cleared.");
-    }
-
-    draw(ctx) {
-        ctx.clearRect(0, 0, this.canvas.width / this.pixelRatio, this.canvas.height / this.pixelRatio);
-        ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
-        ctx.fillRect(0, 0, this.canvas.width / this.pixelRatio, this.canvas.height / this.pixelRatio);
-
-        ctx.fillStyle = 'white';
-        ctx.font = `${Math.floor(this.lineHeight * 0.8)}px Arial`; // ✨ 폰트 크기 동적 조정 (줄 높이의 80%)
-        ctx.textBaseline = 'top';
-
-        for (let i = 0; i < this.logMessages.length; i++) {
-            const message = this.logMessages[i];
-            const y = this.padding + i * this.lineHeight;
-            ctx.fillText(message, this.padding, y);
-        }
+        this.panel.innerHTML = '';
+        console.log('[BattleLogManager] Log messages cleared.');
     }
 }

--- a/js/managers/CompatibilityManager.js
+++ b/js/managers/CompatibilityManager.js
@@ -14,7 +14,7 @@ export class CompatibilityManager {
 
         // 캔버스 참조 보관
         // this.mercenaryPanelCanvas = mercenaryPanelManager ? mercenaryPanelManager.canvas : null; // 이제 필요 없음
-        this.combatLogCanvas = battleLogManager ? battleLogManager.canvas : null;
+        this.combatLogCanvas = battleLogManager ? battleLogManager.panel : null;
 
         this.baseGameWidth = this.measureManager.get('gameResolution.width');
         this.baseGameHeight = this.measureManager.get('gameResolution.height');
@@ -115,15 +115,12 @@ export class CompatibilityManager {
         this.renderer.resizeCanvas(mainGameCanvasWidth, mainGameCanvasHeight);
         console.log(`[CompatibilityManager] Main Canvas adjusted to: ${mainGameCanvasWidth}x${mainGameCanvasHeight}`);
 
-        // 2. 전투 로그 캔버스 해상도 업데이트
+        // 2. 전투 로그 패널 크기 업데이트
         if (this.combatLogCanvas) {
             const combatLogHeight = Math.floor(mainGameCanvasHeight * combatLogExpectedHeightRatio);
             this.combatLogCanvas.style.width = `${mainGameCanvasWidth}px`;
             this.combatLogCanvas.style.height = `${combatLogHeight}px`;
-            if (this.battleLogManager && this.battleLogManager.resizeCanvas) {
-                this.battleLogManager.resizeCanvas();
-            }
-            console.log(`[CompatibilityManager] Combat Log Canvas adjusted to: ${mainGameCanvasWidth}x${combatLogHeight}`);
+            console.log(`[CompatibilityManager] Combat Log Panel adjusted to: ${mainGameCanvasWidth}x${combatLogHeight}`);
         }
 
         // 모든 관련 매니저들의 내부 치수 재계산 호출

--- a/js/managers/DOMEngine.js
+++ b/js/managers/DOMEngine.js
@@ -15,6 +15,10 @@ export class DOMEngine {
 
     _registerElements() {
         this.registerElement('tavern-icon-btn', document.getElementById('tavern-icon-btn'));
+        this.registerElement('territory-screen', document.getElementById('territory-screen'));
+        this.registerElement('gameCanvas', document.getElementById('gameCanvas'));
+        this.registerElement('battle-log-panel', document.getElementById('battle-log-panel'));
+        this.registerElement('hero-panel', document.getElementById('hero-panel'));
     }
 
     _setupEventListeners() {
@@ -35,11 +39,20 @@ export class DOMEngine {
     updateUIForScene(sceneName) {
         console.log(`[DOMEngine] Updating UI for scene: ${sceneName}`);
         const tavernIcon = this.getElement('tavern-icon-btn');
-        if (!tavernIcon) return;
+        const territory = this.getElement('territory-screen');
+        const gameCanvas = this.getElement('gameCanvas');
+        const logPanel = this.getElement('battle-log-panel');
+
         if (sceneName === UI_STATES.MAP_SCREEN) {
-            tavernIcon.classList.remove('hidden');
+            tavernIcon && tavernIcon.classList.remove('hidden');
+            territory && territory.classList.remove('hidden');
+            gameCanvas && gameCanvas.classList.add('hidden');
+            logPanel && logPanel.classList.add('hidden');
         } else {
-            tavernIcon.classList.add('hidden');
+            tavernIcon && tavernIcon.classList.add('hidden');
+            territory && territory.classList.add('hidden');
+            gameCanvas && gameCanvas.classList.remove('hidden');
+            logPanel && logPanel.classList.remove('hidden');
         }
     }
 

--- a/js/managers/MercenaryPanelManager.js
+++ b/js/managers/MercenaryPanelManager.js
@@ -1,93 +1,47 @@
 // js/managers/MercenaryPanelManager.js
 
 export class MercenaryPanelManager {
-    // 생성자에서 캔버스 요소 대신 필요한 매니저들을 직접 받도록 변경합니다.
     constructor(measureManager, battleSimulationManager, logicManager, eventManager) {
         console.log("\uD83D\uDC65 MercenaryPanelManager initialized. Ready to display mercenary details. \uD83D\uDC65");
-        // this.canvas, this.ctx는 이제 더 이상 자체적으로 관리하지 않습니다.
         this.measureManager = measureManager;
-        this.battleSimulationManager = battleSimulationManager; // 유닛 데이터를 가져오기 위함
+        this.battleSimulationManager = battleSimulationManager;
         this.logicManager = logicManager;
         this.eventManager = eventManager;
 
-        // MeasureManager에서 그리드 행/열 정보를 가져옴
         this.gridRows = this.measureManager.get('mercenaryPanel.gridRows');
         this.gridCols = this.measureManager.get('mercenaryPanel.gridCols');
         this.numSlots = this.gridRows * this.gridCols;
-
-        console.log("[MercenaryPanelManager] Initialized as a drawing component.");
     }
 
-    /**
-     * 용병 패널과 그리드를 그립니다.
-     * 이 메서드는 UIEngine에 의해 호출되며, 메인 게임 캔버스의 컨텍스트를 받습니다.
-     * @param {CanvasRenderingContext2D} ctx - 메인 게임 캔버스의 2D 렌더링 컨텍스트
-     * @param {number} panelX - 패널을 그릴 X 좌표
-     * @param {number} panelY - 패널을 그릴 Y 좌표
-     * @param {number} panelWidth - 패널의 너비
-     * @param {number} panelHeight - 패널의 높이
-     */
-    draw(ctx, panelX, panelY, panelWidth, panelHeight) {
-        // 패널 배경 그리기 (반투명 검은색)
-        ctx.clearRect(panelX, panelY, panelWidth, panelHeight); // 기존 내용 지우기
-        ctx.fillStyle = 'rgba(26, 26, 26, 0.9)'; // 반투명 배경
-        ctx.fillRect(panelX, panelY, panelWidth, panelHeight);
-
-        // 슬롯 크기 재계산 (주어진 패널 크기에 맞게)
-        const slotWidth = panelWidth / this.gridCols;
-        const slotHeight = panelHeight / this.gridRows;
-
-        ctx.strokeStyle = '#555';
-        ctx.lineWidth = 1;
-
-        // 그리드 선 그리기
-        for (let i = 0; i <= this.gridCols; i++) {
-            ctx.beginPath();
-            ctx.moveTo(panelX + i * slotWidth, panelY);
-            ctx.lineTo(panelX + i * slotWidth, panelY + panelHeight);
-            ctx.stroke();
+    updatePanel() {
+        const heroPanel = document.getElementById('hero-panel');
+        if (!heroPanel || heroPanel.classList.contains('hidden')) {
+            return;
         }
-        for (let i = 0; i <= this.gridRows; i++) {
-            ctx.beginPath();
-            ctx.moveTo(0, panelY + i * slotHeight); // 패널 영역 전체에 선을 그림
-            ctx.lineTo(panelX + panelWidth, panelY + i * slotHeight);
-            ctx.stroke();
-        }
-
+        heroPanel.innerHTML = '';
         const units = this.battleSimulationManager ? this.battleSimulationManager.unitsOnGrid : [];
-        ctx.fillStyle = 'white';
-        const unitTextFontSize = Math.floor(slotHeight * this.measureManager.get('mercenaryPanel.unitTextFontSizeRatio'));
-        const unitHpFontSize = Math.floor(unitTextFontSize * this.measureManager.get('mercenaryPanel.unitHpFontSizeScale'));
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
 
-        // 각 슬롯에 유닛 정보 그리기
         for (let i = 0; i < this.numSlots; i++) {
-            const row = Math.floor(i / this.gridCols);
-            const col = i % this.gridCols;
-            const x = panelX + col * slotWidth + slotWidth / 2;
-            const y = panelY + row * slotHeight + slotHeight / 2;
-
+            const slot = document.createElement('div');
+            slot.className = 'hero-slot';
             if (units[i]) {
                 const unit = units[i];
-                ctx.font = `${unitTextFontSize}px Arial`;
-                ctx.fillText(`${unit.name}`, x, y - unitTextFontSize * this.measureManager.get('mercenaryPanel.unitTextOffsetYScale'));
-
-                ctx.font = `${unitHpFontSize}px Arial`;
-                ctx.fillText(`HP: ${unit.currentHp}/${unit.baseStats.hp}`, x, y + unitHpFontSize * this.measureManager.get('mercenaryPanel.unitTextOffsetYScale'));
-
-                // ✨ panelImage가 존재하면 우선 사용하고, 없으면 기본 이미지 사용
-                const imageToDraw = unit.panelImage || unit.image;
-                if (imageToDraw) {
-                    const imgSize = Math.min(slotWidth, slotHeight) * this.measureManager.get('mercenaryPanel.unitImageScale');
-                    const imgX = panelX + col * slotWidth + (slotWidth - imgSize) / 2;
-                    const imgY = panelY + row * slotHeight + (slotHeight - imgSize) / 2 - unitTextFontSize * this.measureManager.get('mercenaryPanel.unitImageOffsetYScale');
-                    ctx.drawImage(imageToDraw, imgX, imgY, imgSize, imgSize);
+                const imgSrc = (unit.panelImage || unit.image) && (unit.panelImage || unit.image).src;
+                if (imgSrc) {
+                    const img = document.createElement('img');
+                    img.src = imgSrc;
+                    slot.appendChild(img);
                 }
+                const nameEl = document.createElement('p');
+                nameEl.textContent = unit.name;
+                slot.appendChild(nameEl);
+                const hpEl = document.createElement('p');
+                hpEl.textContent = `HP: ${unit.currentHp}/${unit.baseStats.hp}`;
+                slot.appendChild(hpEl);
             } else {
-                ctx.font = `${unitTextFontSize}px Arial`;
-                ctx.fillText(`Slot ${i + 1}`, x, y);
+                slot.textContent = `Slot ${i + 1}`;
             }
+            heroPanel.appendChild(slot);
         }
     }
 }

--- a/js/managers/UIEngine.js
+++ b/js/managers/UIEngine.js
@@ -17,7 +17,6 @@ export class UIEngine {
         this.ctx = renderer.ctx;
 
         this._currentUIState = UI_STATES.MAP_SCREEN;
-        this.heroPanelVisible = false;
 
         this.recalculateUIDimensions();
 
@@ -54,9 +53,12 @@ export class UIEngine {
 
     // 영웅 패널 가시성 토글
     toggleHeroPanel() {
-        this.heroPanelVisible = !this.heroPanelVisible;
-        console.log(`[UIEngine] Hero Panel Visibility: ${this.heroPanelVisible ? 'Visible' : 'Hidden'}`);
-        // 필요에 따라 UI 상태를 변경할 수 있지만, 오버레이는 현재 UI 상태와 별개로 표시될 수 있습니다.
+        const heroPanel = document.getElementById('hero-panel');
+        if (heroPanel) {
+            heroPanel.classList.toggle('hidden');
+            this.mercenaryPanelManager.updatePanel();
+        }
+        console.log(`[UIEngine] Hero Panel Visibility toggled.`);
     }
 
 
@@ -73,21 +75,7 @@ export class UIEngine {
             // 전투 화면에서는 현재 별도의 상단 텍스트를 표시하지 않습니다.
         }
 
-        // 영웅 패널이 활성화되어 있으면 오버레이로 그립니다.
-        if (this.heroPanelVisible && this.mercenaryPanelManager) {
-            // 오버레이 배경 (반투명)
-            ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
-            ctx.fillRect(0, 0, this.canvas.width / (window.devicePixelRatio || 1), this.canvas.height / (window.devicePixelRatio || 1));
-
-            // 영웅 패널이 그려질 중앙 영역 계산
-            const panelWidth = this.measureManager.get('gameResolution.width') * 0.8; // 캔버스 너비의 80%
-            const panelHeight = this.measureManager.get('gameResolution.height') * 0.7; // 캔버스 높이의 70%
-            const panelX = (this.measureManager.get('gameResolution.width') - panelWidth) / 2;
-            const panelY = (this.measureManager.get('gameResolution.height') - panelHeight) / 2;
-
-            // MercenaryPanelManager의 draw 메서드를 호출하여 메인 캔버스에 그립니다.
-            this.mercenaryPanelManager.draw(ctx, panelX, panelY, panelWidth, panelHeight);
-        }
+        // DOM 기반 영웅 패널은 캔버스에 별도 그리기를 하지 않습니다.
     }
 
     getMapPanelDimensions() {

--- a/style.css
+++ b/style.css
@@ -32,12 +32,18 @@ canvas {
 
 /* 용병 패널 캔버스 스타일은 이제 필요 없습니다. */
 
-/* ✨ 전투 로그 캔버스 전용 스타일 (JS가 크기 제어) */
-#combatLogCanvas {
-    margin-top: 0px; /* 메인 게임 캔버스 위쪽 간격을 제거 */
-    border: 2px solid #f00; /* 구분을 위한 다른 테두리 색상 (빨간색) */
-    flex-shrink: 0;
-    aspect-ratio: 16 / 1.35; /* 메인 캔버스 높이의 약 15% 비율 */
+/* ✨ 전투 로그 패널 스타일 */
+#battle-log-panel {
+    width: 100%;
+    height: 15%;
+    background-color: rgba(0, 0, 0, 0.7);
+    border: 2px solid #f00;
+    color: white;
+    overflow-y: scroll;
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+    box-sizing: border-box;
+    padding: 10px;
 }
 
 /* 메인 게임 캔버스 */
@@ -85,4 +91,40 @@ canvas {
 /* \u2728 요소를 숨기기 위한 헬퍼 클래스 */
 .hidden {
     display: none !important;
+}
+
+/* ✨ 새로운 영웅 패널 스타일 */
+#hero-panel {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 80vw;
+    height: 70vh;
+    background-color: rgba(26, 26, 26, 0.9);
+    border: 2px solid #fff;
+    border-radius: 10px;
+    z-index: 50;
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-template-rows: repeat(2, 1fr);
+    gap: 10px;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.hero-slot {
+    background-color: #333;
+    border: 1px solid #555;
+    border-radius: 5px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    padding: 5px;
+}
+
+.hero-slot img {
+    width: 70%;
 }


### PR DESCRIPTION
## Summary
- move combat log to HTML scrollable panel
- convert hero panel to DOM grid with slots
- update DOMEngine for scene switching and element registration
- revise GameEngine initialization for DOM panels
- fix debug page styling and panel draw logic

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687a6a331c40832785d7ba61f9f5c3ba