### PR TITLE
Fix leftover canvas tooltip

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -879,6 +879,9 @@ export class GameEngine {
             if (this.territoryUIManager) {
                 this.territoryUIManager.cleanup();
             }
+            if (this.territoryInputManager) {
+                this.territoryInputManager.cleanup();
+            }
         });
     }
 

--- a/js/managers/TerritoryInputManager.js
+++ b/js/managers/TerritoryInputManager.js
@@ -6,21 +6,34 @@ export class TerritoryInputManager {
         this.territoryUIManager = territoryUIManager;
         this.hoveredTile = null;
 
-        if (this.canvas) {
-            this.canvas.addEventListener('mousemove', (event) => {
-                const rect = this.canvas.getBoundingClientRect();
-                const mouseX = event.clientX - rect.left;
-                const mouseY = event.clientY - rect.top;
-                this.handleMouseMove(mouseX, mouseY, this.canvas.width, this.canvas.height);
-            });
+        this._onMouseMove = (event) => {
+            const rect = this.canvas.getBoundingClientRect();
+            const mouseX = event.clientX - rect.left;
+            const mouseY = event.clientY - rect.top;
+            this.handleMouseMove(mouseX, mouseY, this.canvas.width, this.canvas.height);
+        };
 
-            this.canvas.addEventListener('mousedown', (event) => {
-                const rect = this.canvas.getBoundingClientRect();
-                const mouseX = event.clientX - rect.left;
-                const mouseY = event.clientY - rect.top;
-                this.handleMouseClick(mouseX, mouseY, this.canvas.width, this.canvas.height);
-            });
+        this._onMouseDown = (event) => {
+            const rect = this.canvas.getBoundingClientRect();
+            const mouseX = event.clientX - rect.left;
+            const mouseY = event.clientY - rect.top;
+            this.handleMouseClick(mouseX, mouseY, this.canvas.width, this.canvas.height);
+        };
+
+        if (this.canvas) {
+            this.canvas.addEventListener('mousemove', this._onMouseMove);
+            this.canvas.addEventListener('mousedown', this._onMouseDown);
         }
+    }
+
+    cleanup() {
+        if (this.canvas) {
+            this.canvas.removeEventListener('mousemove', this._onMouseMove);
+            this.canvas.removeEventListener('mousedown', this._onMouseDown);
+        }
+        this.territoryUIManager.hideTooltip();
+        this.territoryUIManager.stopAnimation('tavern-icon');
+        console.log('[TerritoryInputManager] Event listeners removed.');
     }
 
     handleMouseClick(mouseX, mouseY, canvasWidth, canvasHeight) {


### PR DESCRIPTION
## Summary
- remove lingering canvas-based mouse handlers from territory
- hook cleanup of territory input when leaving map screen

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a760ee2908327bec6120816db79bc