### PR TITLE
Add territory management framework

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -90,6 +90,11 @@ import { PassiveIsAlsoASkillManager } from './managers/PassiveIsAlsoASkillManage
 import { ModifierEngine } from './managers/ModifierEngine.js';
 import { ModifierLogManager } from './managers/ModifierLogManager.js';
 import { DOMEngine } from './managers/DOMEngine.js';
+import { TerritoryEngine } from './managers/TerritoryEngine.js';
+import { TerritoryBackgroundManager } from './managers/TerritoryBackgroundManager.js';
+import { TerritoryUIManager } from './managers/TerritoryUIManager.js';
+import { TerritorySceneManager } from './managers/TerritorySceneManager.js';
+import { TerritoryGridManager } from './managers/TerritoryGridManager.js';
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';
 
 import { UNITS } from '../data/unit.js';
@@ -125,6 +130,7 @@ export class GameEngine {
         // 2. Scene & Logic Managers
         this.sceneEngine = new SceneEngine(this.eraserEngine, this.hideAndSeekManager);
         this.logicManager = new LogicManager(this.measureManager, this.sceneEngine);
+        this.territorySceneManager = new TerritorySceneManager(this.sceneEngine);
 
         // 3. ID & Asset Loading
         this.idManager = new IdManager();
@@ -249,9 +255,15 @@ export class GameEngine {
         this.attackManager = new AttackManager(this.eventManager, this.idManager);
 
         // 13. Scene Registrations & Layer Engine Setup
-        this.sceneEngine.registerScene(UI_STATES.MAP_SCREEN, []); // DOM only, no canvas managers
+        // this.sceneEngine.registerScene(UI_STATES.MAP_SCREEN, []); // TerritorySceneManager handles this scene
         this.sceneEngine.registerScene(UI_STATES.COMBAT_SCREEN, [this.battleStageManager, this.battleGridManager, (ctx) => { this.shadowEngine.draw(ctx); }, this.battleSimulationManager, this.vfxManager]);
         this.sceneEngine.setCurrentScene(UI_STATES.MAP_SCREEN);
+
+        // Initialize territory-related managers
+        this.territoryEngine = new TerritoryEngine(this.eventManager, this.domEngine);
+        this.territoryBackgroundManager = new TerritoryBackgroundManager(this.domEngine);
+        this.territoryUIManager = new TerritoryUIManager(this.eventManager, this.domEngine);
+        this.territoryGridManager = new TerritoryGridManager(this.domEngine);
 
         // --- LAYER REGISTRATION ---
         this.layerEngine.registerLayer('combatScene', (ctx) => {

--- a/js/managers/DOMEngine.js
+++ b/js/managers/DOMEngine.js
@@ -16,6 +16,7 @@ export class DOMEngine {
     _registerElements() {
         this.registerElement('tavern-icon-btn', document.getElementById('tavern-icon-btn'));
         this.registerElement('territory-screen', document.getElementById('territory-screen'));
+        this.registerElement('territory-grid', document.getElementById('territory-grid'));
         this.registerElement('gameCanvas', document.getElementById('gameCanvas'));
         this.registerElement('battle-log-panel', document.getElementById('battle-log-panel'));
         this.registerElement('hero-panel', document.getElementById('hero-panel'));

--- a/js/managers/TerritoryBackgroundManager.js
+++ b/js/managers/TerritoryBackgroundManager.js
@@ -1,0 +1,18 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+export class TerritoryBackgroundManager {
+    constructor(domEngine) {
+        if (GAME_DEBUG_MODE) console.log('\uD83C\uDFDE\uFE0F TerritoryBackgroundManager initialized.');
+        this.domEngine = domEngine;
+        this.territoryScreen = this.domEngine.getElement('territory-screen');
+        this._setupBackground();
+    }
+
+    _setupBackground() {
+        if (this.territoryScreen) {
+            this.territoryScreen.style.backgroundImage = "url('assets/territory/city-1.png')";
+            this.territoryScreen.style.backgroundSize = 'cover';
+            this.territoryScreen.style.backgroundPosition = 'center';
+        }
+    }
+}

--- a/js/managers/TerritoryEngine.js
+++ b/js/managers/TerritoryEngine.js
@@ -1,0 +1,9 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+export class TerritoryEngine {
+    constructor(eventManager, domEngine) {
+        if (GAME_DEBUG_MODE) console.log('\uD83C\uDFE0 TerritoryEngine initialized. Managing the home base.');
+        this.eventManager = eventManager;
+        this.domEngine = domEngine;
+    }
+}

--- a/js/managers/TerritoryGridManager.js
+++ b/js/managers/TerritoryGridManager.js
@@ -1,0 +1,9 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+export class TerritoryGridManager {
+    constructor(domEngine) {
+        if (GAME_DEBUG_MODE) console.log('GRID TerritoryGridManager initialized.');
+        this.domEngine = domEngine;
+        this.gridElement = this.domEngine.getElement('territory-grid');
+    }
+}

--- a/js/managers/TerritorySceneManager.js
+++ b/js/managers/TerritorySceneManager.js
@@ -1,0 +1,13 @@
+import { GAME_DEBUG_MODE, UI_STATES } from '../constants.js';
+
+export class TerritorySceneManager {
+    constructor(sceneEngine) {
+        if (GAME_DEBUG_MODE) console.log('\uD83C\uDFAC TerritorySceneManager initialized.');
+        this.sceneEngine = sceneEngine;
+        this._registerScene();
+    }
+
+    _registerScene() {
+        this.sceneEngine.registerScene(UI_STATES.MAP_SCREEN, []);
+    }
+}

--- a/js/managers/TerritoryUIManager.js
+++ b/js/managers/TerritoryUIManager.js
@@ -1,0 +1,9 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+export class TerritoryUIManager {
+    constructor(eventManager, domEngine) {
+        if (GAME_DEBUG_MODE) console.log('\uD83D\uDCCB TerritoryUIManager initialized.');
+        this.eventManager = eventManager;
+        this.domEngine = domEngine;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -22,6 +22,21 @@ body {
     justify-content: center; /* 세로 중앙 정렬 */
 }
 
+/* \u2728 \uc601\uc9c0 \ud654\uba74 \uc2a4\ud0c0\uc77c \ucd94\uac00 */
+#territory-screen {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    /* background is handled by TerritoryBackgroundManager */
+}
+
+#territory-grid {
+    width: 100%;
+    height: 100%;
+}
+
 canvas {
     border: 2px solid #fff; /* 캔버스 테두리 */
     background-color: #000; /* 캔버스 배경 */


### PR DESCRIPTION
## Summary
- add five managers handling the new territory scene
- wire up the territory managers in `GameEngine`
- register the `territory-grid` element in `DOMEngine`
- style the territory screen and grid

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl` `debug.html`

------
https://chatgpt.com/codex/tasks/task_e_687a82c64bc883278fd150dea4d80a6a