### PR TITLE
Add tavern screen and manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,18 @@
             <div id="territory-grid"></div>
             <img src="assets/territory/tavern-icon.png" id="tavern-icon-btn" alt="여관 아이콘">
         </div>
+
+        <div id="tavern-screen" class="hidden">
+            <div id="tavern-grid">
+                <div id="hire-hero-btn" class="tavern-grid-cell">
+                    <img src="assets/territory/hire-icon.png" alt="영웅 고용">
+                </div>
+                <div class="tavern-grid-cell"></div>
+                <div class="tavern-grid-cell"></div>
+                <div class="tavern-grid-cell"></div>
+            </div>
+        </div>
+
         <canvas id="gameCanvas" class="hidden"></canvas>
         <div id="hero-panel" class="hidden"></div>
         <div id="battle-log-panel" class="hidden"></div>

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -95,6 +95,7 @@ import { TerritoryBackgroundManager } from './managers/TerritoryBackgroundManage
 import { TerritoryUIManager } from './managers/TerritoryUIManager.js';
 import { TerritorySceneManager } from './managers/TerritorySceneManager.js';
 import { TerritoryGridManager } from './managers/TerritoryGridManager.js';
+import { TavernManager } from './managers/TavernManager.js';
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';
 
 import { UNITS } from '../data/unit.js';
@@ -257,6 +258,7 @@ export class GameEngine {
         // 13. Scene Registrations & Layer Engine Setup
         // this.sceneEngine.registerScene(UI_STATES.MAP_SCREEN, []); // TerritorySceneManager handles this scene
         this.sceneEngine.registerScene(UI_STATES.COMBAT_SCREEN, [this.battleStageManager, this.battleGridManager, (ctx) => { this.shadowEngine.draw(ctx); }, this.battleSimulationManager, this.vfxManager]);
+        this.sceneEngine.registerScene(UI_STATES.TAVERN_SCREEN, []);
         this.sceneEngine.setCurrentScene(UI_STATES.MAP_SCREEN);
 
         // Initialize territory-related managers
@@ -264,6 +266,7 @@ export class GameEngine {
         this.territoryBackgroundManager = new TerritoryBackgroundManager(this.domEngine);
         this.territoryUIManager = new TerritoryUIManager(this.eventManager, this.domEngine);
         this.territoryGridManager = new TerritoryGridManager(this.domEngine);
+        this.tavernManager = new TavernManager(this.domEngine, this.sceneEngine, this.uiEngine, this.heroManager);
 
         // --- LAYER REGISTRATION ---
         this.layerEngine.registerLayer('combatScene', (ctx) => {
@@ -533,4 +536,5 @@ export class GameEngine {
     getStackEngine() { return this.stackEngine; }
     getHideAndSeekManager() { return this.hideAndSeekManager; }
     getDOMEngine() { return this.domEngine; }
+    getTavernManager() { return this.tavernManager; }
 }

--- a/js/constants.js
+++ b/js/constants.js
@@ -39,6 +39,7 @@ export const GAME_EVENTS = {
 export const UI_STATES = {
     MAP_SCREEN: 'mapScreen',
     COMBAT_SCREEN: 'combatScreen',
+    TAVERN_SCREEN: 'tavernScreen',
     HERO_PANEL_OVERLAY: 'heroPanelOverlay'
 };
 

--- a/js/managers/DOMEngine.js
+++ b/js/managers/DOMEngine.js
@@ -17,6 +17,9 @@ export class DOMEngine {
         this.registerElement('tavern-icon-btn', document.getElementById('tavern-icon-btn'));
         this.registerElement('territory-screen', document.getElementById('territory-screen'));
         this.registerElement('territory-grid', document.getElementById('territory-grid'));
+        this.registerElement('tavern-screen', document.getElementById('tavern-screen'));
+        this.registerElement('tavern-grid', document.getElementById('tavern-grid'));
+        this.registerElement('hire-hero-btn', document.getElementById('hire-hero-btn'));
         this.registerElement('gameCanvas', document.getElementById('gameCanvas'));
         this.registerElement('battle-log-panel', document.getElementById('battle-log-panel'));
         this.registerElement('hero-panel', document.getElementById('hero-panel'));
@@ -25,15 +28,6 @@ export class DOMEngine {
     }
 
     _setupEventListeners() {
-        const tavernIcon = this.getElement('tavern-icon-btn');
-        if (tavernIcon) {
-            tavernIcon.addEventListener('click', () => {
-                if (!tavernIcon.classList.contains('hidden')) {
-                    console.log('여관 아이콘(HTML 버튼)이 클릭되었습니다!');
-                }
-            });
-        }
-
         this.eventManager.subscribe(GAME_EVENTS.BATTLE_START, () => this.updateUIForScene(UI_STATES.COMBAT_SCREEN));
         this.eventManager.subscribe(GAME_EVENTS.BATTLE_END, () => this.updateUIForScene(UI_STATES.MAP_SCREEN));
     }
@@ -42,6 +36,7 @@ export class DOMEngine {
         console.log(`[DOMEngine] Updating UI for scene: ${sceneName}`);
         const tavernIcon = this.getElement('tavern-icon-btn');
         const territory = this.getElement('territory-screen');
+        const tavernScreen = this.getElement('tavern-screen');
         const gameCanvas = this.getElement('gameCanvas');
         const logPanel = this.getElement('battle-log-panel');
         const battleStartBtn = this.getElement('battleStartHtmlBtn');
@@ -55,6 +50,18 @@ export class DOMEngine {
             recruitBtn?.classList.remove('hidden');
             heroPanelBtn?.classList.remove('hidden');
 
+            tavernScreen?.classList.add('hidden');
+            gameCanvas?.classList.add('hidden');
+            logPanel?.classList.add('hidden');
+        } else if (sceneName === UI_STATES.TAVERN_SCREEN) {
+            tavernScreen?.classList.remove('hidden');
+
+            territory?.classList.add('hidden');
+            tavernIcon?.classList.add('hidden');
+            battleStartBtn?.classList.add('hidden');
+            recruitBtn?.classList.add('hidden');
+            heroPanelBtn?.classList.add('hidden');
+
             gameCanvas?.classList.add('hidden');
             logPanel?.classList.add('hidden');
         } else { // COMBAT_SCREEN
@@ -64,6 +71,7 @@ export class DOMEngine {
             recruitBtn?.classList.add('hidden');
             heroPanelBtn?.classList.add('hidden');
 
+            tavernScreen?.classList.add('hidden');
             gameCanvas?.classList.remove('hidden');
             logPanel?.classList.remove('hidden');
         }

--- a/js/managers/TavernManager.js
+++ b/js/managers/TavernManager.js
@@ -1,0 +1,39 @@
+import { GAME_DEBUG_MODE, UI_STATES } from '../constants.js';
+
+export class TavernManager {
+    constructor(domEngine, sceneEngine, uiEngine, heroManager) {
+        if (GAME_DEBUG_MODE) console.log('🍻 TavernManager initialized.');
+        this.domEngine = domEngine;
+        this.sceneEngine = sceneEngine;
+        this.uiEngine = uiEngine;
+        this.heroManager = heroManager;
+
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        const tavernIcon = this.domEngine.getElement('tavern-icon-btn');
+        if (tavernIcon) {
+            tavernIcon.addEventListener('click', () => this.enterTavern());
+        }
+
+        const hireHeroBtn = this.domEngine.getElement('hire-hero-btn');
+        if (hireHeroBtn) {
+            hireHeroBtn.addEventListener('click', () => this.hireHero());
+        }
+    }
+
+    enterTavern() {
+        if (GAME_DEBUG_MODE) console.log('Entering the tavern...');
+        this.sceneEngine.setCurrentScene(UI_STATES.TAVERN_SCREEN);
+        this.uiEngine.setUIState(UI_STATES.TAVERN_SCREEN);
+        this.domEngine.updateUIForScene(UI_STATES.TAVERN_SCREEN);
+    }
+
+    hireHero() {
+        if (GAME_DEBUG_MODE) {
+            console.log('[TavernManager] "Hire Hero" button clicked. Preparing for class selection...');
+        }
+        alert('영웅의 직업을 선택하는 화면으로 이동할 예정입니다. (현재 개발 중)');
+    }
+}

--- a/style.css
+++ b/style.css
@@ -143,3 +143,52 @@ canvas {
 .hero-slot img {
     width: 70%;
 }
+
+/* ✨ 선술집 화면 스타일 */
+#tavern-screen {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-image: url('assets/territory/tavern-scene.png');
+    background-size: cover;
+    background-position: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#tavern-grid {
+    display: flex;
+    flex-direction: column;
+    width: 15%;
+    height: 80%;
+    gap: 15px;
+}
+
+.tavern-grid-cell {
+    flex: 1;
+    background-color: rgba(0, 0, 0, 0.4);
+    border: 2px solid #4a3c2a;
+    border-radius: 8px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+}
+
+#hire-hero-btn {
+    cursor: pointer;
+    transition: transform 0.2s ease-in-out, background-color 0.2s;
+}
+
+#hire-hero-btn:hover {
+    transform: scale(1.05);
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+#hire-hero-btn img {
+    width: 80%;
+    height: auto;
+}


### PR DESCRIPTION
## Summary
- add new Tavern screen DOM
- style tavern UI
- create TavernManager for tavern interactions
- handle tavern UI state in DOMEngine
- register tavern scene and manager in GameEngine
- expose tavern manager getter
- extend UI_STATES constant

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a86acf50883279e3e00f9fe11b1d1