### PR TITLE
Update tavern grid layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -159,12 +159,13 @@ canvas {
     align-items: center;
 }
 
+
 #tavern-grid {
     display: flex;
-    flex-direction: column;
-    width: 15%;
-    height: 80%;
-    gap: 15px;
+    flex-direction: row; /* ✨ 세로 정렬(column)에서 가로 정렬(row)로 변경 */
+    width: 80%;          /* ✨ 화면 너비의 80%를 차지하도록 변경 */
+    height: 25%;         /* ✨ 화면 높이의 25%를 차지하도록 변경 */
+    gap: 20px;           /* ✨ 그리드 셀 사이의 간격 조정 */
 }
 
 .tavern-grid-cell {
@@ -176,6 +177,7 @@ canvas {
     justify-content: center;
     align-items: center;
     overflow: hidden;
+    aspect-ratio: 2 / 3; /* ✨ 2:3 비율을 유지하도록 설정 */
 }
 
 #hire-hero-btn {


### PR DESCRIPTION
## Summary
- switch `#tavern-grid` to horizontal layout
- set its width to 80%, height to 25% and adjust gap
- keep tavern cells at 2:3 aspect ratio

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a8a9effa88327a7833a2fb09167d6