### PR TITLE
Add hero hire overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,13 @@
                 <div class="tavern-grid-cell"></div>
                 <div class="tavern-grid-cell"></div>
             </div>
+
+            <!-- ✨ 영웅 고용 UI 오버레이 -->
+            <div id="hire-ui-overlay" class="hidden">
+                <button id="prev-class-btn" class="arrow-btn">＜</button>
+                <img id="hire-class-image" src="assets/territory/warrior-hire.png" alt="고용 가능한 용병">
+                <button id="next-class-btn" class="arrow-btn">＞</button>
+            </div>
         </div>
 
         <canvas id="gameCanvas" class="hidden"></canvas>

--- a/js/managers/DOMEngine.js
+++ b/js/managers/DOMEngine.js
@@ -20,6 +20,11 @@ export class DOMEngine {
         this.registerElement('tavern-screen', document.getElementById('tavern-screen'));
         this.registerElement('tavern-grid', document.getElementById('tavern-grid'));
         this.registerElement('hire-hero-btn', document.getElementById('hire-hero-btn'));
+        // ✨ 고용 UI 요소 등록
+        this.registerElement('hire-ui-overlay', document.getElementById('hire-ui-overlay'));
+        this.registerElement('hire-class-image', document.getElementById('hire-class-image'));
+        this.registerElement('prev-class-btn', document.getElementById('prev-class-btn'));
+        this.registerElement('next-class-btn', document.getElementById('next-class-btn'));
         this.registerElement('gameCanvas', document.getElementById('gameCanvas'));
         this.registerElement('battle-log-panel', document.getElementById('battle-log-panel'));
         this.registerElement('hero-panel', document.getElementById('hero-panel'));

--- a/js/managers/TavernManager.js
+++ b/js/managers/TavernManager.js
@@ -8,19 +8,48 @@ export class TavernManager {
         this.uiEngine = uiEngine;
         this.heroManager = heroManager;
 
+        // ✨ 고용 가능한 직업 및 관련 이미지 정보
+        this.availableClasses = ['warrior', 'archer', 'mage'];
+        this.classIllustrations = {
+            'warrior': 'assets/territory/warrior-hire.png',
+            'archer': 'assets/territory/archer-hire.png',
+            'mage': 'assets/territory/mage-hire.png'
+        };
+        this.currentClassIndex = 0;
+
+        // ✨ UI 요소 캐싱
+        this.tavernGrid = this.domEngine.getElement('tavern-grid');
+        this.hireUI = this.domEngine.getElement('hire-ui-overlay');
+        this.hireImageElement = this.domEngine.getElement('hire-class-image');
+        this.prevButton = this.domEngine.getElement('prev-class-btn');
+        this.nextButton = this.domEngine.getElement('next-class-btn');
+
         this._setupEventListeners();
     }
 
     _setupEventListeners() {
+        // 선술집 아이콘 클릭
         const tavernIcon = this.domEngine.getElement('tavern-icon-btn');
-        if (tavernIcon) {
-            tavernIcon.addEventListener('click', () => this.enterTavern());
-        }
+        tavernIcon?.addEventListener('click', () => this.enterTavern());
 
+        // 기본 그리드 안의 영웅 고용 버튼
         const hireHeroBtn = this.domEngine.getElement('hire-hero-btn');
-        if (hireHeroBtn) {
-            hireHeroBtn.addEventListener('click', () => this.hireHero());
-        }
+        hireHeroBtn?.addEventListener('click', () => this.openHireUI());
+
+        // 오버레이 내부 버튼과 이벤트
+        this.prevButton?.addEventListener('click', () => this._showPrevClass());
+        this.nextButton?.addEventListener('click', () => this._showNextClass());
+
+        this.hireUI?.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY > 0) {
+                this._showNextClass();
+            } else {
+                this._showPrevClass();
+            }
+        });
+
+        this.hireImageElement?.addEventListener('click', () => this.hireSelectedHero());
     }
 
     enterTavern() {
@@ -28,12 +57,48 @@ export class TavernManager {
         this.sceneEngine.setCurrentScene(UI_STATES.TAVERN_SCREEN);
         this.uiEngine.setUIState(UI_STATES.TAVERN_SCREEN);
         this.domEngine.updateUIForScene(UI_STATES.TAVERN_SCREEN);
+        this.closeHireUI();
     }
 
-    hireHero() {
-        if (GAME_DEBUG_MODE) {
-            console.log('[TavernManager] "Hire Hero" button clicked. Preparing for class selection...');
+    // ✨ 고용 UI 열기
+    openHireUI() {
+        if (GAME_DEBUG_MODE) console.log('[TavernManager] Opening Hire UI.');
+        this.tavernGrid?.classList.add('hidden');
+        this.hireUI?.classList.remove('hidden');
+        this._updateHireUI();
+    }
+
+    // ✨ 고용 UI 닫기
+    closeHireUI() {
+        this.hireUI?.classList.add('hidden');
+        this.tavernGrid?.classList.remove('hidden');
+    }
+
+    _updateHireUI() {
+        const currentClass = this.availableClasses[this.currentClassIndex];
+        if (this.hireImageElement && this.classIllustrations[currentClass]) {
+            this.hireImageElement.src = this.classIllustrations[currentClass];
+            this.hireImageElement.alt = `고용 가능한 ${currentClass}`;
+        } else {
+            console.warn(`Illustration for ${currentClass} not found.`);
+            this.hireImageElement.src = '';
         }
-        alert('영웅의 직업을 선택하는 화면으로 이동할 예정입니다. (현재 개발 중)');
+    }
+
+    _showPrevClass() {
+        this.currentClassIndex = (this.currentClassIndex - 1 + this.availableClasses.length) % this.availableClasses.length;
+        this._updateHireUI();
+    }
+
+    _showNextClass() {
+        this.currentClassIndex = (this.currentClassIndex + 1) % this.availableClasses.length;
+        this._updateHireUI();
+    }
+
+    hireSelectedHero() {
+        const currentClass = this.availableClasses[this.currentClassIndex];
+        if (GAME_DEBUG_MODE) console.log(`Attempting to hire a ${currentClass}.`);
+        alert(`${currentClass}(을)를 고용합니다! (실제 고용 로직은 추후 구현)`);
+        this.closeHireUI();
     }
 }

--- a/style.css
+++ b/style.css
@@ -194,3 +194,51 @@ canvas {
     width: 80%;
     height: auto;
 }
+
+/* ✨ 영웅 고용 UI 스타일 */
+#hire-ui-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 30px;
+    z-index: 20;
+}
+
+#hire-class-image {
+    height: 70%;
+    aspect-ratio: 2 / 3;
+    object-fit: contain;
+    border: 4px solid #c5b8a3;
+    border-radius: 10px;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+    cursor: pointer;
+    transition: transform 0.2s ease-in-out;
+}
+
+#hire-class-image:hover {
+    transform: scale(1.03);
+}
+
+.arrow-btn {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 3em;
+    font-weight: bold;
+    cursor: pointer;
+    padding: 20px;
+    opacity: 0.7;
+    transition: opacity 0.2s, transform 0.2s;
+    user-select: none;
+}
+
+.arrow-btn:hover {
+    opacity: 1;
+    transform: scale(1.1);
+}


### PR DESCRIPTION
## Summary
- add hero hire overlay HTML structure
- style overlay with image and arrow buttons
- implement hire overlay logic in `TavernManager`
- register hire overlay elements in `DOMEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687a9109b0c88327997bc11e61683fab