### PR TITLE
Fix barrier bar update in DOMVFXEngine

### DIFF
--- a/js/managers/DOMVFXEngine.js
+++ b/js/managers/DOMVFXEngine.js
@@ -105,7 +105,7 @@ export class DOMVFXEngine {
             const hpRatio = Math.max(0, unit.currentHp) / unit.baseStats.hp;
             ui.hpBar.style.width = `${hpRatio * 100}%`;
 
-            const barrierValue = this.battleSimulationManager.statusEffectManager.getEffectValue(unitId, 'barrier') || 0;
+            const barrierValue = unit.currentBarrier || 0;
             if (barrierValue > 0) {
                 const barrierRatio = Math.min(hpRatio + (barrierValue / unit.baseStats.hp), 1);
                 ui.barrierBar.style.width = `${barrierRatio * 100}%`;


### PR DESCRIPTION
## Summary
- avoid undefined `statusEffectManager` in DOMVFXEngine
- read unit barrier directly from `currentBarrier`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b643f02fc83279bd809b2aa1d5188