### PR TITLE
Add gradient-based unit shadows

### DIFF
--- a/js/managers/ShadowEngine.js
+++ b/js/managers/ShadowEngine.js
@@ -26,6 +26,8 @@ export class ShadowEngine {
         // 그림자 오프셋 (유닛 타일 크기 대비 비율) - 45도 느낌
         this.shadowOffsetXRatio = 0.3;
         this.shadowOffsetYRatio = 0.3;
+        // 그림자 내부 반경 비율 (그라디언트 시작 지점)
+        this.shadowGradientInnerRatio = 0.1;
     }
 
     /**
@@ -74,8 +76,8 @@ export class ShadowEngine {
             );
 
             ctx.save();
-            ctx.globalAlpha = this.baseShadowOpacity;
-            ctx.fillStyle = 'black';
+    // 그라디언트를 사용하여 그림자 가장자리가 부드럽게 퍼지도록 함
+            ctx.globalAlpha = 1;
 
             const offsetX = effectiveTileSize * this.shadowOffsetXRatio;
             const offsetY = effectiveTileSize * this.shadowOffsetYRatio;
@@ -96,6 +98,17 @@ export class ShadowEngine {
                 0,
                 Math.PI * 2
             );
+            const gradient = ctx.createRadialGradient(
+                shadowDrawX + effectiveTileSize / 2,
+                shadowDrawY + effectiveTileSize * 0.9,
+                (effectiveTileSize * this.shadowGradientInnerRatio) / 2,
+                shadowDrawX + effectiveTileSize / 2,
+                shadowDrawY + effectiveTileSize * 0.9,
+                effectiveTileSize / 2
+            );
+            gradient.addColorStop(0, `rgba(0, 0, 0, ${this.baseShadowOpacity})`);
+            gradient.addColorStop(1, 'rgba(0,0,0,0)');
+            ctx.fillStyle = gradient;
             ctx.fill();
 
             ctx.restore();

--- a/tests/unit/shadowEngineUnitTests.js
+++ b/tests/unit/shadowEngineUnitTests.js
@@ -32,6 +32,7 @@ export function runShadowEngineUnitTests() {
         beginPath: function() { this.beginPathCalled = true; },
         ellipse: function() { this.ellipseCalled = true; },
         fill: function() { this.fillCalled = true; },
+        createRadialGradient: function() { this.gradientCalled = true; return { addColorStop: () => {} }; },
         translate: () => {},
         scale: () => {},
         // 속성 추적
@@ -41,6 +42,7 @@ export function runShadowEngineUnitTests() {
         beginPathCalled: false,
         ellipseCalled: false,
         fillCalled: false,
+        gradientCalled: false,
     };
 
 
@@ -85,12 +87,13 @@ export function runShadowEngineUnitTests() {
     testCount++;
     mockCtx.ellipseCalled = false;
     mockCtx.fillCalled = false;
+    mockCtx.gradientCalled = false;
     try {
         const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
         se.setShadowsEnabled(true);
         se.draw(mockCtx);
 
-        if (mockCtx.ellipseCalled && mockCtx.fillCalled) {
+        if (mockCtx.ellipseCalled && mockCtx.fillCalled && mockCtx.gradientCalled) {
             if (GAME_DEBUG_MODE) console.log("ShadowEngine: draw called drawing operations when enabled. [PASS]"); // \u2728 조건부 로그
             passCount++;
         } else {
@@ -104,12 +107,13 @@ export function runShadowEngineUnitTests() {
     testCount++;
     mockCtx.ellipseCalled = false;
     mockCtx.fillCalled = false;
+    mockCtx.gradientCalled = false;
     try {
         const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
         se.setShadowsEnabled(false);
         se.draw(mockCtx);
 
-        if (!mockCtx.ellipseCalled && !mockCtx.fillCalled) {
+        if (!mockCtx.ellipseCalled && !mockCtx.fillCalled && !mockCtx.gradientCalled) {
             if (GAME_DEBUG_MODE) console.log("ShadowEngine: draw correctly skipped drawing when disabled. [PASS]"); // \u2728 조건부 로그
             passCount++;
         } else {
@@ -126,12 +130,13 @@ export function runShadowEngineUnitTests() {
     mockBattleSimulationManager.unitsOnGrid = [mockDeadUnit];
     mockCtx.ellipseCalled = false;
     mockCtx.fillCalled = false;
+    mockCtx.gradientCalled = false;
     try {
         const se = new ShadowEngine(mockBattleSimulationManager, mockAnimationManager, mockMeasureManager);
         se.setShadowsEnabled(true);
         se.draw(mockCtx);
 
-        if (!mockCtx.ellipseCalled && !mockCtx.fillCalled) {
+        if (!mockCtx.ellipseCalled && !mockCtx.fillCalled && !mockCtx.gradientCalled) {
             if (GAME_DEBUG_MODE) console.log("ShadowEngine: draw correctly skipped drawing for dead unit. [PASS]"); // \u2728 조건부 로그
             passCount++;
         } else {


### PR DESCRIPTION
## Summary
- enhance ShadowEngine with radial gradient for smooth elliptical shadows
- extend ShadowEngine tests for gradient drawing

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687b899d791c8327868e07857cdb6ae5