### PR TITLE
Add Pixi overlay UI

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -191,6 +191,7 @@
     </div>
     <!-- ✨ 전투 시작을 위한 별도의 HTML 버튼 -->
     <button id="battleStartHtmlBtn" class="game-button">전투 시작</button>
+    <script src="https://cdn.jsdelivr.net/npm/pixi.js@7/dist/pixi.min.js"></script>
     <script type="module">
     import { GameEngine } from './js/GameEngine.js'; // <-- GameEngine 불러오기
     import {

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
     <!-- ✨ 캔버스 버튼 외에 별도의 HTML 전투 시작 버튼 -->
     <button id="recruitWarriorBtn" class="game-button" style="bottom: 10px; left: calc(50% - 150px);">전사 고용</button>
     <button id="battleStartHtmlBtn" class="game-button" style="bottom: 10px; left: calc(50% + 10px);">전투 시작</button>
+    <script src="https://cdn.jsdelivr.net/npm/pixi.js@7/dist/pixi.min.js"></script>
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -6,6 +6,7 @@ import { GuardianManager } from './managers/GuardianManager.js';
 import { MeasureManager } from './managers/MeasureManager.js';
 import { MapManager } from './managers/MapManager.js';
 import { UIEngine } from './managers/UIEngine.js';
+import { PixiUIOverlay } from './managers/PixiUIOverlay.js';
 import { LayerEngine } from './managers/LayerEngine.js';
 import { SceneEngine } from './managers/SceneEngine.js';
 import { CameraEngine } from './managers/CameraEngine.js';
@@ -191,6 +192,13 @@ export class GameEngine {
         this.vfxManager.assetLoaderManager = this.assetLoaderManager;
         this.vfxManager.statusEffectManager = this.statusEffectManager;
         this.bindingManager = new BindingManager();
+        this.pixiUIOverlay = new PixiUIOverlay(
+            this.renderer,
+            this.measureManager,
+            this.battleSimulationManager,
+            this.animationManager,
+            this.eventManager
+        );
 
         // 8. Timing & Movement Engines
         this.delayEngine = new DelayEngine();
@@ -396,6 +404,7 @@ export class GameEngine {
         this.vfxManager.update(deltaTime);
         this.particleEngine.update(deltaTime);
         this.detailInfoManager.update(deltaTime);
+        this.pixiUIOverlay.update(deltaTime);
         const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
             const { drawX, drawY } = this.animationManager.getRenderPosition(unit.id, unit.gridX, unit.gridY, effectiveTileSize, gridOffsetX, gridOffsetY);
@@ -476,6 +485,7 @@ export class GameEngine {
     getMercenaryPanelManager() { return this.mercenaryPanelManager; }
     getBattleLogManager() { return this.battleLogManager; }
     getVFXManager() { return this.vfxManager; }
+    getPixiUIOverlay() { return this.pixiUIOverlay; }
     getBindingManager() { return this.bindingManager; }
     getDelayEngine() { return this.delayEngine; }
     getTimingEngine() { return this.timingEngine; }

--- a/js/managers/PixiUIOverlay.js
+++ b/js/managers/PixiUIOverlay.js
@@ -1,0 +1,141 @@
+import * as PIXI from 'pixi.js';
+import { GAME_DEBUG_MODE, GAME_EVENTS } from '../constants.js';
+
+export class PixiUIOverlay {
+    constructor(renderer, measureManager, battleSimulationManager, animationManager, eventManager) {
+        if (GAME_DEBUG_MODE) console.log('\uD83D\uDD8C️ PixiUIOverlay initialized.');
+        this.renderer = renderer;
+        this.measureManager = measureManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.animationManager = animationManager;
+        this.eventManager = eventManager;
+
+        const view = document.createElement('canvas');
+        view.id = 'pixi-ui-canvas';
+        view.style.position = 'absolute';
+        view.style.left = '0';
+        view.style.top = '0';
+        view.style.pointerEvents = 'none';
+        renderer.canvas.parentNode.appendChild(view);
+
+        this.app = new PIXI.Application({
+            view,
+            width: renderer.canvas.width / renderer.pixelRatio,
+            height: renderer.canvas.height / renderer.pixelRatio,
+            transparent: true,
+            autoStart: false
+        });
+
+        this.uiContainer = new PIXI.Container();
+        this.app.stage.addChild(this.uiContainer);
+
+        this.hpBars = new Map();
+        this.nameTexts = new Map();
+        this.buffIcons = new Map();
+        this.damageTexts = [];
+
+        this.eventManager.subscribe(GAME_EVENTS.DISPLAY_DAMAGE, this._onDisplayDamage.bind(this));
+    }
+
+    resize(width, height) {
+        this.app.renderer.resize(width, height);
+    }
+
+    _onDisplayDamage({ unitId, damage, color }) {
+        const style = new PIXI.TextStyle({
+            fontFamily: 'Arial',
+            fontSize: this.measureManager.get('vfx.damageNumberBaseFontSize'),
+            fill: color || '#FF4500',
+            stroke: '#000',
+            strokeThickness: 2
+        });
+        const text = new PIXI.Text(String(damage), style);
+        text.anchor.set(0.5, 1);
+        this.damageTexts.push({ text, start: performance.now(), unitId });
+        this.uiContainer.addChild(text);
+    }
+
+    update(delta) {
+        const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
+        for (const unit of this.battleSimulationManager.unitsOnGrid) {
+            let bar = this.hpBars.get(unit.id);
+            let nameText = this.nameTexts.get(unit.id);
+            let buff = this.buffIcons.get(unit.id);
+            if (!bar) {
+                bar = new PIXI.Graphics();
+                this.uiContainer.addChild(bar);
+                this.hpBars.set(unit.id, bar);
+                nameText = new PIXI.Text(unit.name, { fontSize: effectiveTileSize * 0.25, fill: '#ffffff' });
+                nameText.anchor.set(0.5, 0);
+                this.uiContainer.addChild(nameText);
+                this.nameTexts.set(unit.id, nameText);
+                buff = new PIXI.Graphics();
+                this.uiContainer.addChild(buff);
+                this.buffIcons.set(unit.id, buff);
+            }
+            const { drawX, drawY } = this.animationManager.getRenderPosition(
+                unit.id,
+                unit.gridX,
+                unit.gridY,
+                effectiveTileSize,
+                gridOffsetX,
+                gridOffsetY
+            );
+            const centerX = drawX + effectiveTileSize / 2;
+            const centerY = drawY + effectiveTileSize / 2;
+            const barWidth = effectiveTileSize * this.measureManager.get('vfx.hpBarWidthRatio');
+            const barHeight = effectiveTileSize * this.measureManager.get('vfx.hpBarHeightRatio');
+            const offsetY = -(barHeight + this.measureManager.get('vfx.hpBarVerticalOffset'));
+            const maxHp = unit.baseStats?.hp || unit.currentHp || 1;
+            const currentHp = unit.currentHp !== undefined ? unit.currentHp : maxHp;
+            const ratio = currentHp / maxHp;
+            bar.clear();
+            bar.beginFill(0x333333, 0.8);
+            bar.drawRect(-barWidth/2, offsetY, barWidth, barHeight);
+            bar.endFill();
+            bar.beginFill(0x00ff00);
+            bar.drawRect(-barWidth/2, offsetY, barWidth * ratio, barHeight);
+            bar.endFill();
+            bar.position.set(centerX, centerY);
+
+            nameText.text = unit.name;
+            nameText.position.set(centerX, drawY + effectiveTileSize + 2);
+
+            buff.clear();
+            buff.beginFill(0xffff00);
+            const iconSize = effectiveTileSize * 0.2;
+            buff.drawCircle(0, offsetY - iconSize, iconSize / 2);
+            buff.endFill();
+            buff.position.set(centerX, centerY);
+        }
+
+        const now = performance.now();
+        const duration = this.measureManager.get('vfx.damageNumberDuration');
+        this.damageTexts = this.damageTexts.filter(obj => {
+            const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === obj.unitId);
+            if (!unit) {
+                this.uiContainer.removeChild(obj.text);
+                return false;
+            }
+            const progress = (now - obj.start) / duration;
+            if (progress >= 1) {
+                this.uiContainer.removeChild(obj.text);
+                return false;
+            }
+            const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
+            const { drawX, drawY } = this.animationManager.getRenderPosition(
+                unit.id,
+                unit.gridX,
+                unit.gridY,
+                effectiveTileSize,
+                gridOffsetX,
+                gridOffsetY
+            );
+            obj.text.position.set(drawX + effectiveTileSize / 2, drawY - progress * effectiveTileSize * 0.5);
+            obj.text.alpha = 1 - progress;
+            return true;
+        });
+
+        this.app.render();
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,750 @@
+{
+  "name": "muscle-and-blood",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "muscle-and-blood",
+      "version": "1.0.0",
+      "dependencies": {
+        "pixi.js": "^7.4.3"
+      }
+    },
+    "node_modules/@pixi/accessibility": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.3.tgz",
+      "integrity": "sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/events": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/app": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.3.tgz",
+      "integrity": "sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/assets": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
+      "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/css-font-loading-module": "^0.0.12"
+      },
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/color": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.3.tgz",
+      "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/colord": "^2.9.6"
+      }
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.3.tgz",
+      "integrity": "sha512-uJ3CC+lNX4HIxs6IxEESO50/0A1KxSVm6CO9UlkXzTsNj9ynmdy5BkJ1dzii7LCdqGcHIXHO01yvKuUbJBBQtw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/constants": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
+      "integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/math": "7.4.3",
+        "@pixi/runner": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/ticker": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/@pixi/display": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
+      "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
+      "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/extensions": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
+      "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/extract": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.3.tgz",
+      "integrity": "sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-alpha": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.3.tgz",
+      "integrity": "sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-blur": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.3.tgz",
+      "integrity": "sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-color-matrix": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.3.tgz",
+      "integrity": "sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-displacement": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.3.tgz",
+      "integrity": "sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-fxaa": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.3.tgz",
+      "integrity": "sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-noise": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.3.tgz",
+      "integrity": "sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/graphics": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
+      "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/math": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
+      "integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/mesh": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
+      "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mesh-extras": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.3.tgz",
+      "integrity": "sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/mesh": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.3.tgz",
+      "integrity": "sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.3.tgz",
+      "integrity": "sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-get-global-position": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.3.tgz",
+      "integrity": "sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/particle-container": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.3.tgz",
+      "integrity": "sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/prepare": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.3.tgz",
+      "integrity": "sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/graphics": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/runner": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
+      "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/settings": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.3.tgz",
+      "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/constants": "7.4.3",
+        "@types/css-font-loading-module": "^0.0.12",
+        "ismobilejs": "^1.1.0"
+      }
+    },
+    "node_modules/@pixi/sprite": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
+      "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/sprite-animated": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.3.tgz",
+      "integrity": "sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/sprite-tiling": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.3.tgz",
+      "integrity": "sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/spritesheet": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.3.tgz",
+      "integrity": "sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
+      "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.3.tgz",
+      "integrity": "sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/mesh": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text-html": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.3.tgz",
+      "integrity": "sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/ticker": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
+      "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/extensions": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/utils": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
+      "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
+        "url": "^0.11.0"
+      }
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/earcut": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.3.tgz",
+      "integrity": "sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/accessibility": "7.4.3",
+        "@pixi/app": "7.4.3",
+        "@pixi/assets": "7.4.3",
+        "@pixi/compressed-textures": "7.4.3",
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/events": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/extract": "7.4.3",
+        "@pixi/filter-alpha": "7.4.3",
+        "@pixi/filter-blur": "7.4.3",
+        "@pixi/filter-color-matrix": "7.4.3",
+        "@pixi/filter-displacement": "7.4.3",
+        "@pixi/filter-fxaa": "7.4.3",
+        "@pixi/filter-noise": "7.4.3",
+        "@pixi/graphics": "7.4.3",
+        "@pixi/mesh": "7.4.3",
+        "@pixi/mesh-extras": "7.4.3",
+        "@pixi/mixin-cache-as-bitmap": "7.4.3",
+        "@pixi/mixin-get-child-by-name": "7.4.3",
+        "@pixi/mixin-get-global-position": "7.4.3",
+        "@pixi/particle-container": "7.4.3",
+        "@pixi/prepare": "7.4.3",
+        "@pixi/sprite": "7.4.3",
+        "@pixi/sprite-animated": "7.4.3",
+        "@pixi/sprite-tiling": "7.4.3",
+        "@pixi/spritesheet": "7.4.3",
+        "@pixi/text": "7.4.3",
+        "@pixi/text-bitmap": "7.4.3",
+        "@pixi/text-html": "7.4.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test"
+  },
+  "dependencies": {
+    "pixi.js": "^7.4.3"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -15,6 +15,7 @@ export { runWarriorSkillsAIUnitTests } from './unit/warriorSkillsAIUnitTests.js'
 export { runShadowEngineUnitTests } from './unit/shadowEngineUnitTests.js'; // ✨ ShadowEngine 단위 테스트 추가
 export { runMicrocosmHeroEngineUnitTests } from './unit/microcosmHeroEngineUnitTests.js'; // 👈 추가
 export { runSoundEngineUnitTests } from './unit/soundEngineUnitTests.js'; // <-- 이 줄 추가
+export { runPixiUIOverlayUnitTests } from './unit/pixiUIOverlayUnitTests.js';
 
 // new unit tests
 export { runSceneEngineUnitTests } from './unit/sceneEngineUnitTests.js';
@@ -96,4 +97,5 @@ export function runEngineTests(
     runMovingManagerUnitTests();
     runWarriorSkillsAIUnitTests();
     runShadowEngineUnitTests();
+    runPixiUIOverlayUnitTests();
 }

--- a/tests/unit/pixiUIOverlayUnitTests.js
+++ b/tests/unit/pixiUIOverlayUnitTests.js
@@ -1,0 +1,32 @@
+import { PixiUIOverlay } from '../../js/managers/PixiUIOverlay.js';
+import { GAME_DEBUG_MODE, GAME_EVENTS } from '../../js/constants.js';
+
+export function runPixiUIOverlayUnitTests() {
+    if (!GAME_DEBUG_MODE) return;
+    console.log('--- PixiUIOverlay Unit Test Start ---');
+
+    const mockRenderer = {
+        canvas: { width: 800, height: 600, parentNode: { appendChild: () => {} } },
+        pixelRatio: 1
+    };
+    const mockMeasure = { get: () => 20 };
+    const mockBSM = { unitsOnGrid: [], getGridRenderParameters: () => ({ effectiveTileSize: 32, gridOffsetX:0, gridOffsetY:0 }) };
+    const mockAnim = { getRenderPosition: () => ({ drawX:0, drawY:0 }) };
+    const mockEventManager = { subscribe: () => {} };
+
+    let overlay;
+    try {
+        overlay = new PixiUIOverlay(mockRenderer, mockMeasure, mockBSM, mockAnim, mockEventManager);
+        console.log('PixiUIOverlay: Initialized. [PASS]');
+    } catch (e) {
+        console.error('PixiUIOverlay: Initialization failed. [FAIL]', e);
+    }
+
+    if (overlay && overlay.app) {
+        console.log('PixiUIOverlay: Application created. [PASS]');
+    } else {
+        console.error('PixiUIOverlay: Application missing. [FAIL]');
+    }
+
+    console.log('--- PixiUIOverlay Unit Test End ---');
+}


### PR DESCRIPTION
## Summary
- create `PixiUIOverlay` manager for rendering HP bars, buff icons, damage numbers, and unit names using Pixi.js
- load Pixi.js in `index.html` and `debug.html`
- integrate overlay manager into `GameEngine`
- add minimal unit tests for the new overlay and export from test index
- include Pixi.js dependency in `package.json`

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687b8c50c0fc83279cb6efae5890542c