### PR TITLE
Fix Pixi import

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -191,7 +191,6 @@
     </div>
     <!-- ✨ 전투 시작을 위한 별도의 HTML 버튼 -->
     <button id="battleStartHtmlBtn" class="game-button">전투 시작</button>
-    <script src="https://cdn.jsdelivr.net/npm/pixi.js@7/dist/pixi.min.js"></script>
     <script type="module">
     import { GameEngine } from './js/GameEngine.js'; // <-- GameEngine 불러오기
     import {

--- a/index.html
+++ b/index.html
@@ -39,7 +39,6 @@
     <!-- ✨ 캔버스 버튼 외에 별도의 HTML 전투 시작 버튼 -->
     <button id="recruitWarriorBtn" class="game-button" style="bottom: 10px; left: calc(50% - 150px);">전사 고용</button>
     <button id="battleStartHtmlBtn" class="game-button" style="bottom: 10px; left: calc(50% + 10px);">전투 시작</button>
-    <script src="https://cdn.jsdelivr.net/npm/pixi.js@7/dist/pixi.min.js"></script>
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/managers/PixiUIOverlay.js
+++ b/js/managers/PixiUIOverlay.js
@@ -1,4 +1,7 @@
-import * as PIXI from 'pixi.js';
+// Use the ESM build of Pixi.js directly from the CDN. This avoids the browser
+// error about failing to resolve the module specifier when running without a
+// bundler.
+import * as PIXI from 'https://cdn.jsdelivr.net/npm/pixi.js@7/dist/pixi.mjs';
 import { GAME_DEBUG_MODE, GAME_EVENTS } from '../constants.js';
 
 export class PixiUIOverlay {


### PR DESCRIPTION
## Summary
- load Pixi as an ES module directly from CDN
- drop unused pixi script tags from HTML files

## Testing
- `npm test`
- `python3 -m http.server 8000` (manual check via `curl`)

------
https://chatgpt.com/codex/tasks/task_e_687bc74741148327a3e2be7fb21ac74f