### PR TITLE
Update Pixi overlay canvas transparency

### DIFF
--- a/js/managers/PixiUIOverlay.js
+++ b/js/managers/PixiUIOverlay.js
@@ -25,7 +25,7 @@ export class PixiUIOverlay {
             view,
             width: renderer.canvas.width / renderer.pixelRatio,
             height: renderer.canvas.height / renderer.pixelRatio,
-            transparent: true,
+            backgroundAlpha: 0,
             autoStart: false
         });
 

--- a/style.css
+++ b/style.css
@@ -242,3 +242,9 @@ canvas {
     opacity: 1;
     transform: scale(1.1);
 }
+
+/* \u2728 Pixi.js UI \uc624\ubc84\ub808\uc774 \ucee4\ube14\ub9ac\uc2a4\ub97c \uc704\ud55c \uc2a4\ud0c0\uc77c \ucd94\uac00 */
+#pixi-ui-canvas {
+    background-color: transparent !important;
+    border: none !important;
+}


### PR DESCRIPTION
## Summary
- use `backgroundAlpha: 0` when creating Pixi Application
- style Pixi UI overlay canvas so it stays transparent

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687bcb1cf7988327a34a084e1722fd0c