### PR TITLE
Fix Pixi import path

### DIFF
--- a/js/managers/ShadowEngine.js
+++ b/js/managers/ShadowEngine.js
@@ -1,7 +1,9 @@
 // js/managers/ShadowEngine.js
 
 import { GAME_DEBUG_MODE } from '../constants.js';
-import * as PIXI from 'pixi.js';
+// Use the same CDN build of Pixi.js as the PixiUIOverlay to avoid module
+// resolution issues when running without a bundler.
+import * as PIXI from 'https://cdn.jsdelivr.net/npm/pixi.js@7/dist/pixi.mjs';
 
 export class ShadowEngine {
     constructor(battleSimulationManager, animationManager, pixiUIOverlay) {


### PR DESCRIPTION
## Summary
- ensure Pixi.js is loaded via CDN in ShadowEngine

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687bd4cf80248327bd712cb052c21a6f