### PR TITLE
Add OffscreenTextManager integration

### DIFF
--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -28,6 +28,7 @@ import { SkillIconManager } from './managers/SkillIconManager.js';
 import { StatusIconManager } from './managers/StatusIconManager.js';
 import { BindingManager } from './managers/BindingManager.js';
 import { PixiUIOverlay } from './managers/PixiUIOverlay.js';
+import { OffscreenTextManager } from './managers/OffscreenTextManager.js';
 import { BattleCalculationManager } from './managers/BattleCalculationManager.js';
 import { MercenaryPanelManager } from './managers/MercenaryPanelManager.js';
 import { RuleManager } from './managers/RuleManager.js';
@@ -165,13 +166,17 @@ export class GameEngine {
         this.battleSimulationManager.animationManager = this.animationManager;
         this.animationManager.battleSimulationManager = this.battleSimulationManager;
 
+        this.offscreenTextManager = new OffscreenTextManager();
+
         // Pixi 기반 UI 오버레이를 먼저 생성합니다.
         this.pixiUIOverlay = new PixiUIOverlay(
             this.renderer,
             this.measureManager,
             this.battleSimulationManager,
             this.animationManager,
-            this.eventManager
+            this.eventManager,
+            this.sceneEngine,
+            this.offscreenTextManager
         );
 
         // 그림자 엔진은 PixiUIOverlay를 활용하도록 변경합니다.

--- a/js/managers/OffscreenTextManager.js
+++ b/js/managers/OffscreenTextManager.js
@@ -1,0 +1,68 @@
+import { GAME_DEBUG_MODE } from '../constants.js';
+
+/**
+ * 텍스트를 고해상도 오프스크린 캔버스에 그린 후,
+ * 이미지 데이터로 변환하여 캐싱하는 매니저입니다.
+ * 이를 통해 캔버스 위에서도 선명한 텍스트를 출력할 수 있습니다.
+ */
+export class OffscreenTextManager {
+    constructor() {
+        if (GAME_DEBUG_MODE) console.log('🖼️ OffscreenTextManager initialized. Ready to render crisp text.');
+        this.textCanvas = document.createElement('canvas');
+        this.textCtx = this.textCanvas.getContext('2d');
+        this.textCache = new Map(); // key: cacheKey, value: HTMLImageElement
+        this.renderScale = 2; // 2배 해상도로 렌더링하여 선명도 확보
+    }
+
+    /**
+     * 텍스트와 설정을 기반으로 고품질 텍스트 이미지를 생성하거나 캐시에서 반환합니다.
+     * @param {string} text - 렌더링할 텍스트
+     * @param {object} options - 렌더링 옵션
+     * @param {number} options.fontSize - 기본 폰트 크기
+     * @param {string} options.fontColor - 폰트 색상
+     * @param {string} options.bgColor - 배경 색상
+     * @returns {HTMLImageElement} 렌더링된 텍스트 이미지
+     */
+    getOrCreateText(text, { fontSize = 12, fontColor = '#FFFFFF', bgColor = '#000000' }) {
+        const cacheKey = `${text}-${fontSize}-${fontColor}-${bgColor}`;
+        if (this.textCache.has(cacheKey)) {
+            return this.textCache.get(cacheKey);
+        }
+
+        const scaledFontSize = fontSize * this.renderScale;
+        const padding = 5 * this.renderScale;
+
+        this.textCtx.font = `bold ${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
+        const textMetrics = this.textCtx.measureText(text);
+
+        const canvasWidth = textMetrics.width + padding * 2;
+        const canvasHeight = scaledFontSize + padding * 2;
+
+        this.textCanvas.width = canvasWidth;
+        this.textCanvas.height = canvasHeight;
+
+        // 배경 그리기
+        this.textCtx.fillStyle = bgColor;
+        this.textCtx.fillRect(0, 0, canvasWidth, canvasHeight);
+
+        // 텍스트 그리기
+        this.textCtx.fillStyle = fontColor;
+        this.textCtx.font = `bold ${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
+        this.textCtx.textAlign = 'center';
+        this.textCtx.textBaseline = 'middle';
+        this.textCtx.fillText(text, canvasWidth / 2, canvasHeight / 2);
+
+        const textImage = new Image();
+        textImage.src = this.textCanvas.toDataURL();
+        this.textCache.set(cacheKey, textImage);
+
+        return textImage;
+    }
+
+    /**
+     * 캐시를 비웁니다. (필요시 사용)
+     */
+    clearCache() {
+        this.textCache.clear();
+    }
+}

--- a/js/managers/PixiUIOverlay.js
+++ b/js/managers/PixiUIOverlay.js
@@ -1,203 +1,127 @@
-// Use the ESM build of Pixi.js directly from the CDN. This avoids the browser
-// error about failing to resolve the module specifier when running without a
-// bundler.
 import * as PIXI from 'https://cdn.jsdelivr.net/npm/pixi.js@7/dist/pixi.mjs';
-import { GAME_DEBUG_MODE, GAME_EVENTS, ATTACK_TYPES } from '../constants.js';
+import { GAME_DEBUG_MODE, GAME_EVENTS, ATTACK_TYPES, UI_STATES } from '../constants.js';
 
 export class PixiUIOverlay {
-    constructor(renderer, measureManager, battleSimulationManager, animationManager, eventManager) {
-        if (GAME_DEBUG_MODE) console.log('\uD83D\uDD8C️ PixiUIOverlay initialized.');
+    // OffscreenTextManager를 생성자에서 받습니다.
+    constructor(renderer, measureManager, battleSimulationManager, animationManager, eventManager, sceneEngine, offscreenTextManager) {
+        if (GAME_DEBUG_MODE) console.log('🎨 PixiUIOverlay initialized.');
         this.renderer = renderer;
         this.measureManager = measureManager;
         this.battleSimulationManager = battleSimulationManager;
         this.animationManager = animationManager;
         this.eventManager = eventManager;
+        this.sceneEngine = sceneEngine;
+        this.offscreenTextManager = offscreenTextManager; // OffscreenTextManager 인스턴스 저장
 
         const view = document.createElement('canvas');
         view.id = 'pixi-ui-canvas';
-        view.style.position = 'absolute';
-        view.style.left = '0';
-        view.style.top = '0';
-        view.style.pointerEvents = 'none';
         renderer.canvas.parentNode.appendChild(view);
 
-        this.app = new PIXI.Application({
-            view,
-            width: renderer.canvas.width / renderer.pixelRatio,
-            height: renderer.canvas.height / renderer.pixelRatio,
-            backgroundAlpha: 0,
-            autoStart: false
-        });
-
+        this.app = new PIXI.Application({ view, width: renderer.canvas.width / renderer.pixelRatio, height: renderer.canvas.height / renderer.pixelRatio, backgroundAlpha: 0, autoStart: false });
         this.uiContainer = new PIXI.Container();
         this.app.stage.addChild(this.uiContainer);
-
-        // 그림자 전용 컨테이너를 추가하여 다른 UI 요소와 분리합니다.
         this.shadowContainer = new PIXI.Container();
-        // stage의 최하단에 위치하도록 인덱스 0에 배치합니다.
         this.app.stage.addChildAt(this.shadowContainer, 0);
 
         this.hpBars = new Map();
-        this.nameTexts = new Map();
-        this.nameBackgrounds = new Map();
-        this.buffIcons = new Map();
+        this.nameSprites = new Map(); // PIXI.Text 대신 PIXI.Sprite를 사용합니다.
         this.damageTexts = [];
 
         this.eventManager.subscribe(GAME_EVENTS.DISPLAY_DAMAGE, this._onDisplayDamage.bind(this));
     }
 
-    resize(width, height) {
-        this.app.renderer.resize(width, height);
-    }
+    resize(width, height) { this.app.renderer.resize(width, height); }
 
     _onDisplayDamage({ unitId, damage, color }) {
-        const style = new PIXI.TextStyle({
-            fontFamily: 'Arial',
-            fontSize: this.measureManager.get('vfx.damageNumberBaseFontSize'),
-            fill: color || '#FF4500',
-            stroke: '#000',
-            strokeThickness: 2
-        });
+        if (this.sceneEngine.getCurrentSceneName() !== UI_STATES.COMBAT_SCREEN) return;
+        const style = new PIXI.TextStyle({ fontFamily: 'Arial', fontSize: this.measureManager.get('vfx.damageNumberBaseFontSize'), fill: color || '#FF4500', stroke: '#000', strokeThickness: 2, resolution: 2 });
         const text = new PIXI.Text(String(damage), style);
         text.anchor.set(0.5, 1);
         this.damageTexts.push({ text, start: performance.now(), unitId });
         this.uiContainer.addChild(text);
     }
 
-    update(delta) {
-        const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
-        for (const unit of this.battleSimulationManager.unitsOnGrid) {
-            if (unit.currentHp <= 0) {
-                if (this.nameTexts.has(unit.id)) {
-                    this.uiContainer.removeChild(this.nameTexts.get(unit.id));
-                    this.nameTexts.delete(unit.id);
-                }
-                if (this.nameBackgrounds.has(unit.id)) {
-                    this.uiContainer.removeChild(this.nameBackgrounds.get(unit.id));
-                    this.nameBackgrounds.delete(unit.id);
-                }
-                continue;
-            }
+    _cleanupUnitUI(unitId) {
+        if (this.hpBars.has(unitId)) { this.hpBars.get(unitId).destroy(); this.hpBars.delete(unitId); }
+        if (this.nameSprites.has(unitId)) { this.nameSprites.get(unitId).destroy(); this.nameSprites.delete(unitId); }
+    }
 
+    update(delta) {
+        if (this.sceneEngine.getCurrentSceneName() !== UI_STATES.COMBAT_SCREEN) {
+            if (this.uiContainer.children.length > 0) {
+                this.uiContainer.removeChildren().forEach(child => child.destroy());
+                this.hpBars.clear(); this.nameSprites.clear(); this.damageTexts = [];
+            }
+            return;
+        }
+
+        const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
+        const aliveUnitIds = new Set(this.battleSimulationManager.unitsOnGrid.map(u => u.id));
+
+        for (const unitId of this.hpBars.keys()) {
+            if (!aliveUnitIds.has(unitId)) this._cleanupUnitUI(unitId);
+        }
+
+        for (const unit of this.battleSimulationManager.unitsOnGrid) {
+            if (unit.currentHp <= 0) { this._cleanupUnitUI(unit.id); continue; }
+
+            let nameSprite = this.nameSprites.get(unit.id);
             let bar = this.hpBars.get(unit.id);
-            let nameText = this.nameTexts.get(unit.id);
-            let nameBg = this.nameBackgrounds.get(unit.id);
-            let buff = this.buffIcons.get(unit.id);
-            if (!bar) {
+
+            if (!nameSprite) {
+                const bgColor = unit.type === ATTACK_TYPES.MERCENARY ? 'rgba(0, 51, 204, 0.8)' : 'rgba(204, 0, 0, 0.8)';
+                const fontSize = Math.round(effectiveTileSize * 0.18);
+
+                // OffscreenTextManager를 통해 텍스트 이미지를 생성합니다.
+                const nameImage = this.offscreenTextManager.getOrCreateText(unit.name, { fontSize: fontSize, bgColor: bgColor });
+
+                // 생성된 이미지로 PixiJS 텍스처와 스프라이트를 만듭니다.
+                const texture = PIXI.Texture.from(nameImage);
+                nameSprite = new PIXI.Sprite(texture);
+                nameSprite.anchor.set(0.5, 0);
+                this.uiContainer.addChild(nameSprite);
+                this.nameSprites.set(unit.id, nameSprite);
+
                 bar = new PIXI.Graphics();
                 this.uiContainer.addChild(bar);
                 this.hpBars.set(unit.id, bar);
-
-                const textStyle = new PIXI.TextStyle({
-                    fontFamily: 'Arial',
-                    fontSize: effectiveTileSize * 0.2,
-                    fill: '#ffffff',
-                    stroke: '#000000',
-                    strokeThickness: 3
-                });
-                nameText = new PIXI.Text(unit.name, textStyle);
-                nameText.anchor.set(0.5, 0);
-                this.uiContainer.addChild(nameText);
-                this.nameTexts.set(unit.id, nameText);
-
-                nameBg = new PIXI.Graphics();
-                this.uiContainer.addChild(nameBg);
-                this.nameBackgrounds.set(unit.id, nameBg);
-
-                buff = new PIXI.Graphics();
-                this.uiContainer.addChild(buff);
-                this.buffIcons.set(unit.id, buff);
             }
-            const { drawX, drawY } = this.animationManager.getRenderPosition(
-                unit.id,
-                unit.gridX,
-                unit.gridY,
-                effectiveTileSize,
-                gridOffsetX,
-                gridOffsetY
-            );
+
+            const { drawX, drawY } = this.animationManager.getRenderPosition(unit.id, unit.gridX, unit.gridY, effectiveTileSize, gridOffsetX, gridOffsetY);
             const centerX = drawX + effectiveTileSize / 2;
-            const centerY = drawY + effectiveTileSize / 2;
-            const barWidth = effectiveTileSize * this.measureManager.get('vfx.hpBarWidthRatio');
-            const barHeight = effectiveTileSize * this.measureManager.get('vfx.hpBarHeightRatio');
-            const offsetY = -(barHeight + this.measureManager.get('vfx.hpBarVerticalOffset'));
-            const maxHp = unit.baseStats?.hp || unit.currentHp || 1;
-            const currentHp = unit.currentHp !== undefined ? unit.currentHp : maxHp;
-            const ratio = currentHp / maxHp;
+
+            // 이름표 위치 설정
+            const nameYPosition = drawY + effectiveTileSize + 5;
+            nameSprite.position.set(centerX, nameYPosition);
+
+            // HP 바 로직
+            const barWidth = effectiveTileSize * 0.8;
+            const barHeight = effectiveTileSize * 0.1;
+            const barYOffset = drawY + effectiveTileSize - barHeight;
+            const maxHp = unit.baseStats?.hp || 1;
+            const hpRatio = Math.max(0, unit.currentHp / maxHp);
+
             bar.clear();
             bar.beginFill(0x333333, 0.8);
-            bar.drawRect(-barWidth/2, offsetY, barWidth, barHeight);
+            bar.drawRect(centerX - barWidth / 2, barYOffset, barWidth, barHeight);
             bar.endFill();
             bar.beginFill(0x00ff00);
-            bar.drawRect(-barWidth/2, offsetY, barWidth * ratio, barHeight);
+            bar.drawRect(centerX - barWidth / 2, barYOffset, barWidth * hpRatio, barHeight);
             bar.endFill();
-            bar.position.set(centerX, centerY);
-
-            // Update name text and background
-            const padding = 4;
-            const nameYPosition = drawY + effectiveTileSize + 5;
-
-            nameText.text = unit.name;
-            nameText.position.set(centerX, nameYPosition);
-
-            const bgColor = unit.type === ATTACK_TYPES.MERCENARY ? 0x0000ff : 0xff0000;
-            nameBg.clear();
-            nameBg.beginFill(bgColor, 0.7);
-            nameBg.drawRect(
-                -nameText.width / 2 - padding,
-                -padding / 2,
-                nameText.width + padding * 2,
-                nameText.height + padding
-            );
-            nameBg.endFill();
-            nameBg.position.set(centerX, nameYPosition + nameText.height / 2);
-
-            buff.clear();
-            buff.beginFill(0xffff00);
-            const iconSize = effectiveTileSize * 0.2;
-            buff.drawCircle(0, offsetY - iconSize, iconSize / 2);
-            buff.endFill();
-            buff.position.set(centerX, centerY);
         }
 
         const now = performance.now();
         const duration = this.measureManager.get('vfx.damageNumberDuration');
         this.damageTexts = this.damageTexts.filter(obj => {
             const unit = this.battleSimulationManager.unitsOnGrid.find(u => u.id === obj.unitId);
-            if (!unit) {
-                this.uiContainer.removeChild(obj.text);
-                return false;
-            }
+            if (!unit) { obj.text.destroy(); return false; }
             const progress = (now - obj.start) / duration;
-            if (progress >= 1) {
-                this.uiContainer.removeChild(obj.text);
-                return false;
-            }
-            const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
-            const { drawX, drawY } = this.animationManager.getRenderPosition(
-                unit.id,
-                unit.gridX,
-                unit.gridY,
-                effectiveTileSize,
-                gridOffsetX,
-                gridOffsetY
-            );
+            if (progress >= 1) { obj.text.destroy(); return false; }
+            const { drawX, drawY } = this.animationManager.getRenderPosition(unit.id, unit.gridX, unit.gridY, effectiveTileSize, gridOffsetX, gridOffsetY);
             obj.text.position.set(drawX + effectiveTileSize / 2, drawY - progress * effectiveTileSize * 0.5);
             obj.text.alpha = 1 - progress;
             return true;
         });
-
-        if (GAME_DEBUG_MODE && Math.random() < 0.05) { // 콘솔이 너무 지저분해지지 않도록 로그 빈도를 조절합니다.
-            console.groupCollapsed(`[PixiUIOverlay Debug] Rendering Stats`);
-            console.log(`- HP Bars in Map: ${this.hpBars.size}`);
-            console.log(`- Active Damage Texts: ${this.damageTexts.length}`);
-            console.log(`- Shadow Elements in Container: ${this.shadowContainer.children.length}`);
-            console.log(`- UI Elements in Container: ${this.uiContainer.children.length}`);
-            console.log('---');
-            console.log('Shadow Container Children:', this.shadowContainer.children);
-            console.log('UI Container Children:', this.uiContainer.children);
-            console.groupEnd();
-        }
 
         this.app.render();
     }

--- a/tests/unit/pixiUIOverlayUnitTests.js
+++ b/tests/unit/pixiUIOverlayUnitTests.js
@@ -13,10 +13,20 @@ export function runPixiUIOverlayUnitTests() {
     const mockBSM = { unitsOnGrid: [], getGridRenderParameters: () => ({ effectiveTileSize: 32, gridOffsetX:0, gridOffsetY:0 }) };
     const mockAnim = { getRenderPosition: () => ({ drawX:0, drawY:0 }) };
     const mockEventManager = { subscribe: () => {} };
+    const mockSceneEngine = { getCurrentSceneName: () => 'combatScreen' };
+    const mockOffscreenTextManager = { getOrCreateText: () => new Image(), clearCache: () => {} };
 
     let overlay;
     try {
-        overlay = new PixiUIOverlay(mockRenderer, mockMeasure, mockBSM, mockAnim, mockEventManager);
+        overlay = new PixiUIOverlay(
+            mockRenderer,
+            mockMeasure,
+            mockBSM,
+            mockAnim,
+            mockEventManager,
+            mockSceneEngine,
+            mockOffscreenTextManager
+        );
         console.log('PixiUIOverlay: Initialized. [PASS]');
     } catch (e) {
         console.error('PixiUIOverlay: Initialization failed. [FAIL]', e);


### PR DESCRIPTION
## Summary
- implement OffscreenTextManager for cached text rendering
- connect OffscreenTextManager to GameEngine and PixiUIOverlay
- update PixiUIOverlay to draw nameplates from offscreen text
- adjust PixiUIOverlay unit test for new constructor

## Testing
- `npm test`
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/debug.html`


------
https://chatgpt.com/codex/tasks/task_e_687bfac2472c83279fe936eafd1f0c5f