### PR TITLE
Use canvas for unit name rendering

### DIFF
--- a/js/managers/OffscreenTextManager.js
+++ b/js/managers/OffscreenTextManager.js
@@ -1,16 +1,17 @@
 import { GAME_DEBUG_MODE } from '../constants.js';
 
 /**
- * 텍스트를 고해상도 오프스크린 캔버스에 그린 후,
- * 이미지 데이터로 변환하여 캐싱하는 매니저입니다.
- * 이를 통해 캔버스 위에서도 선명한 텍스트를 출력할 수 있습니다.
+ * 텍스트를 고해상도 오프스크린 캔버스에 그려
+ * 완성된 캔버스 요소 자체를 캐싱하는 매니저입니다.
+ * 이를 통해 캔버스 위에서도 선명한 텍스트를 즉시 사용할 수 있습니다.
  */
 export class OffscreenTextManager {
     constructor() {
         if (GAME_DEBUG_MODE) console.log('🖼️ OffscreenTextManager initialized. Ready to render crisp text.');
         this.textCanvas = document.createElement('canvas');
         this.textCtx = this.textCanvas.getContext('2d');
-        this.textCache = new Map(); // key: cacheKey, value: HTMLImageElement
+        // 캐시 값은 이제 HTMLCanvasElement를 저장합니다.
+        this.textCache = new Map();
         this.renderScale = 2; // 2배 해상도로 렌더링하여 선명도 확보
     }
 
@@ -21,7 +22,7 @@ export class OffscreenTextManager {
      * @param {number} options.fontSize - 기본 폰트 크기
      * @param {string} options.fontColor - 폰트 색상
      * @param {string} options.bgColor - 배경 색상
-     * @returns {HTMLImageElement} 렌더링된 텍스트 이미지
+     * @returns {HTMLCanvasElement} 렌더링된 텍스트가 그려진 캔버스 요소
      */
     getOrCreateText(text, { fontSize = 12, fontColor = '#FFFFFF', bgColor = '#000000' }) {
         const cacheKey = `${text}-${fontSize}-${fontColor}-${bgColor}`;
@@ -29,34 +30,48 @@ export class OffscreenTextManager {
             return this.textCache.get(cacheKey);
         }
 
+        // 새로운 캔버스를 만들어 텍스트를 그린 뒤 캐싱합니다.
+        const newCanvas = document.createElement('canvas');
+        const newCtx = newCanvas.getContext('2d');
+
         const scaledFontSize = fontSize * this.renderScale;
         const padding = 5 * this.renderScale;
 
-        this.textCtx.font = `bold ${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
-        const textMetrics = this.textCtx.measureText(text);
+        newCtx.font = `bold ${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
+        const textMetrics = newCtx.measureText(text);
 
         const canvasWidth = textMetrics.width + padding * 2;
         const canvasHeight = scaledFontSize + padding * 2;
 
-        this.textCanvas.width = canvasWidth;
-        this.textCanvas.height = canvasHeight;
+        newCanvas.width = canvasWidth;
+        newCanvas.height = canvasHeight;
 
-        // 배경 그리기
-        this.textCtx.fillStyle = bgColor;
-        this.textCtx.fillRect(0, 0, canvasWidth, canvasHeight);
+        // 배경 그리기 (모서리를 살짝 둥글게 처리합니다)
+        newCtx.fillStyle = bgColor;
+        newCtx.beginPath();
+        newCtx.moveTo(4, 0);
+        newCtx.lineTo(canvasWidth - 4, 0);
+        newCtx.quadraticCurveTo(canvasWidth, 0, canvasWidth, 4);
+        newCtx.lineTo(canvasWidth, canvasHeight - 4);
+        newCtx.quadraticCurveTo(canvasWidth, canvasHeight, canvasWidth - 4, canvasHeight);
+        newCtx.lineTo(4, canvasHeight);
+        newCtx.quadraticCurveTo(0, canvasHeight, 0, canvasHeight - 4);
+        newCtx.lineTo(0, 4);
+        newCtx.quadraticCurveTo(0, 0, 4, 0);
+        newCtx.closePath();
+        newCtx.fill();
 
         // 텍스트 그리기
-        this.textCtx.fillStyle = fontColor;
-        this.textCtx.font = `bold ${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
-        this.textCtx.textAlign = 'center';
-        this.textCtx.textBaseline = 'middle';
-        this.textCtx.fillText(text, canvasWidth / 2, canvasHeight / 2);
+        newCtx.fillStyle = fontColor;
+        newCtx.font = `bold ${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
+        newCtx.textAlign = 'center';
+        newCtx.textBaseline = 'middle';
+        newCtx.fillText(text, canvasWidth / 2, canvasHeight / 2);
 
-        const textImage = new Image();
-        textImage.src = this.textCanvas.toDataURL();
-        this.textCache.set(cacheKey, textImage);
+        // 완성된 캔버스를 캐시 후 반환합니다.
+        this.textCache.set(cacheKey, newCanvas);
 
-        return textImage;
+        return newCanvas;
     }
 
     /**

--- a/js/managers/PixiUIOverlay.js
+++ b/js/managers/PixiUIOverlay.js
@@ -72,13 +72,15 @@ export class PixiUIOverlay {
                 const bgColor = unit.type === ATTACK_TYPES.MERCENARY ? 'rgba(0, 51, 204, 0.8)' : 'rgba(204, 0, 0, 0.8)';
                 const fontSize = Math.round(effectiveTileSize * 0.18);
 
-                // OffscreenTextManager를 통해 텍스트 이미지를 생성합니다.
-                const nameImage = this.offscreenTextManager.getOrCreateText(unit.name, { fontSize: fontSize, bgColor: bgColor });
+                // OffscreenTextManager로부터 캔버스를 받아 텍스처를 생성합니다.
+                const nameCanvas = this.offscreenTextManager.getOrCreateText(unit.name, { fontSize: fontSize, bgColor: bgColor });
 
-                // 생성된 이미지로 PixiJS 텍스처와 스프라이트를 만듭니다.
-                const texture = PIXI.Texture.from(nameImage);
+                // 캔버스는 이미 렌더링 완료된 상태이므로 바로 텍스처로 변환합니다.
+                const texture = PIXI.Texture.from(nameCanvas);
                 nameSprite = new PIXI.Sprite(texture);
                 nameSprite.anchor.set(0.5, 0);
+                // OffscreenTextManager의 렌더링 스케일만큼 다시 줄여 원래 크기로 맞춥니다.
+                nameSprite.scale.set(1 / this.offscreenTextManager.renderScale);
                 this.uiContainer.addChild(nameSprite);
                 this.nameSprites.set(unit.id, nameSprite);
 

--- a/tests/unit/pixiUIOverlayUnitTests.js
+++ b/tests/unit/pixiUIOverlayUnitTests.js
@@ -14,7 +14,7 @@ export function runPixiUIOverlayUnitTests() {
     const mockAnim = { getRenderPosition: () => ({ drawX:0, drawY:0 }) };
     const mockEventManager = { subscribe: () => {} };
     const mockSceneEngine = { getCurrentSceneName: () => 'combatScreen' };
-    const mockOffscreenTextManager = { getOrCreateText: () => new Image(), clearCache: () => {} };
+    const mockOffscreenTextManager = { getOrCreateText: () => document.createElement('canvas'), clearCache: () => {} };
 
     let overlay;
     try {


### PR DESCRIPTION
## Summary
- refactor `OffscreenTextManager` to cache canvas elements instead of Images
- create name label textures in `PixiUIOverlay` from the returned canvas
- adjust unit test mocks for new return type

## Testing
- `npm test`
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687bfdeff7d08327b0fa12bc881a37fa