### PR TITLE
Add DOM overlay for combat UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,10 @@
             </div>
         </div>
 
-        <canvas id="gameCanvas" class="hidden"></canvas>
+        <div id="canvas-wrapper" class="hidden">
+            <canvas id="gameCanvas"></canvas>
+            <div id="dom-ui-container"></div>
+        </div>
         <div id="hero-panel" class="hidden"></div>
         <div id="battle-log-panel" class="hidden"></div>
     </div>

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -27,8 +27,7 @@ import { CanvasBridgeManager } from './managers/CanvasBridgeManager.js';
 import { SkillIconManager } from './managers/SkillIconManager.js';
 import { StatusIconManager } from './managers/StatusIconManager.js';
 import { BindingManager } from './managers/BindingManager.js';
-import { PixiUIOverlay } from './managers/PixiUIOverlay.js';
-import { OffscreenTextManager } from './managers/OffscreenTextManager.js';
+import { DOMUIManager } from './managers/DOMUIManager.js';
 import { BattleCalculationManager } from './managers/BattleCalculationManager.js';
 import { MercenaryPanelManager } from './managers/MercenaryPanelManager.js';
 import { RuleManager } from './managers/RuleManager.js';
@@ -120,6 +119,7 @@ export class GameEngine {
         this.eventManager.subscribe(GAME_EVENTS.CRITICAL_ERROR, this._handleCriticalError.bind(this));
 
         this.domEngine = new DOMEngine(this.eventManager);
+        this.domUIManager = new DOMUIManager(this);
         this.judgementManager = new JudgementManager(this.eventManager);
         this.stackEngine = new StackEngine(this.eventManager);
         this.guardianManager = new GuardianManager();
@@ -166,24 +166,10 @@ export class GameEngine {
         this.battleSimulationManager.animationManager = this.animationManager;
         this.animationManager.battleSimulationManager = this.battleSimulationManager;
 
-        this.offscreenTextManager = new OffscreenTextManager();
-
-        // Pixi 기반 UI 오버레이를 먼저 생성합니다.
-        this.pixiUIOverlay = new PixiUIOverlay(
-            this.renderer,
-            this.measureManager,
-            this.battleSimulationManager,
-            this.animationManager,
-            this.eventManager,
-            this.sceneEngine,
-            this.offscreenTextManager
-        );
-
-        // 그림자 엔진은 PixiUIOverlay를 활용하도록 변경합니다.
         this.shadowEngine = new ShadowEngine(
             this.battleSimulationManager,
             this.animationManager,
-            this.pixiUIOverlay
+            this.renderer
         );
 
         // 6. UI, Input, Log & Other Managers
@@ -419,7 +405,7 @@ export class GameEngine {
         this.detailInfoManager.update(deltaTime);
         // 그림자 정보를 먼저 갱신한 뒤 UI 오버레이를 업데이트합니다.
         this.shadowEngine.update(deltaTime);
-        this.pixiUIOverlay.update(deltaTime);
+        this.domUIManager.update();
         const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
             const { drawX, drawY } = this.animationManager.getRenderPosition(unit.id, unit.gridX, unit.gridY, effectiveTileSize, gridOffsetX, gridOffsetY);

--- a/js/managers/DOMUIManager.js
+++ b/js/managers/DOMUIManager.js
@@ -1,0 +1,81 @@
+// js/managers/DOMUIManager.js
+
+import { UI_STATES, ATTACK_TYPES } from '../constants.js';
+
+export class DOMUIManager {
+    constructor(gameEngine) {
+        console.log('DOMUIManager: Initialized.');
+        this.battleSimManager = gameEngine.getBattleSimulationManager();
+        this.cameraEngine = gameEngine.getCameraEngine();
+        this.sceneEngine = gameEngine.getSceneEngine();
+        this.animationManager = gameEngine.getAnimationManager();
+
+        this.uiContainer = document.getElementById('dom-ui-container');
+        this.unitElements = new Map(); // key: unitId, value: { wrapper, hpBar, name }
+    }
+
+    _createUnitElement(unit) {
+        const element = document.createElement('div');
+        element.className = 'unit-ui';
+
+        const name = document.createElement('div');
+        name.className = 'unit-name';
+        name.textContent = unit.name;
+        name.style.backgroundColor = unit.type === ATTACK_TYPES.MERCENARY ? 'blue' : 'red';
+
+        const hpBar = document.createElement('div');
+        hpBar.className = 'hp-bar';
+
+        const hpBarCurrent = document.createElement('div');
+        hpBarCurrent.className = 'hp-bar-current';
+
+        hpBar.appendChild(hpBarCurrent);
+        element.appendChild(name);
+        element.appendChild(hpBar);
+
+        this.uiContainer.appendChild(element);
+
+        this.unitElements.set(unit.id, { wrapper: element, hpBar: hpBarCurrent, name: name });
+    }
+
+    update() {
+        if (this.sceneEngine.getCurrentSceneName() !== UI_STATES.COMBAT_SCREEN) {
+            this.uiContainer.style.display = 'none';
+            return;
+        }
+
+        this.uiContainer.style.display = 'block';
+
+        const aliveUnitIds = new Set(this.battleSimManager.unitsOnGrid.filter(u => u.currentHp > 0).map(u => u.id));
+        const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimManager.getGridRenderParameters();
+
+        for (const unit of this.battleSimManager.unitsOnGrid) {
+            if (unit.currentHp <= 0) continue;
+
+            if (!this.unitElements.has(unit.id)) {
+                this._createUnitElement(unit);
+            }
+
+            const elements = this.unitElements.get(unit.id);
+            const { wrapper, hpBar } = elements;
+
+            const worldPos = this.animationManager.getRenderPosition(unit.id, unit.gridX, unit.gridY, effectiveTileSize, gridOffsetX, gridOffsetY);
+            const screenX = (worldPos.drawX * this.cameraEngine.zoom) + this.cameraEngine.x;
+            const screenY = (worldPos.drawY * this.cameraEngine.zoom) + this.cameraEngine.y;
+
+            const finalX = screenX + (effectiveTileSize * this.cameraEngine.zoom / 2);
+            const finalY = screenY + (effectiveTileSize * this.cameraEngine.zoom);
+
+            wrapper.style.transform = `translate(-50%, 0) translate(${finalX}px, ${finalY}px) scale(${this.cameraEngine.zoom})`;
+
+            hpBar.style.width = `${(unit.currentHp / unit.baseStats.hp) * 100}%`;
+        }
+
+        for (const unitId of this.unitElements.keys()) {
+            if (!aliveUnitIds.has(unitId)) {
+                this.unitElements.get(unitId).wrapper.remove();
+                this.unitElements.delete(unitId);
+            }
+        }
+    }
+}

--- a/style.css
+++ b/style.css
@@ -67,6 +67,62 @@ canvas {
     aspect-ratio: 16 / 9;
 }
 
+/* ✨ 캔버스 래퍼: 캔버스와 DOM UI의 위치 기준점이 됩니다. */
+#canvas-wrapper {
+    position: relative;
+}
+
+/* ✨ DOM UI 컨테이너: 캔버스 위에 투명하게 떠 있도록 설정합니다. */
+#dom-ui-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+/* 개별 유닛 UI 요소 (이름표 + 체력바)의 기본 스타일 */
+.unit-ui {
+    position: absolute;
+    top: -5px;
+    left: 0;
+    transform-origin: center top;
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: center;
+    gap: 2px;
+    will-change: transform;
+}
+
+.unit-name {
+    color: white;
+    font-size: 14px;
+    font-family: "Nanum Gothic", Arial, sans-serif;
+    font-weight: bold;
+    padding: 2px 8px;
+    border-radius: 4px;
+    text-shadow: 1px 1px 2px black;
+    white-space: nowrap;
+}
+
+.hp-bar {
+    width: 60px;
+    height: 8px;
+    background-color: rgba(0, 0, 0, 0.7);
+    border: 1px solid #222;
+    border-radius: 4px;
+}
+
+.hp-bar-current {
+    width: 100%;
+    height: 100%;
+    background-color: #28a745;
+    border-radius: 3px;
+    transition: width 0.2s ease;
+}
+
 /* ✨ HTML 전투 시작 버튼 스타일 */
 .game-button {
     background-color: darkgreen;
@@ -243,8 +299,3 @@ canvas {
     transform: scale(1.1);
 }
 
-/* \u2728 Pixi.js UI \uc624\ubc84\ub808\uc774 \ucee4\ube14\ub9ac\uc2a4\ub97c \uc704\ud55c \uc2a4\ud0c0\uc77c \ucd94\uac00 */
-#pixi-ui-canvas {
-    background-color: transparent !important;
-    border: none !important;
-}


### PR DESCRIPTION
## Summary
- allow DOM elements over the canvas with a new wrapper
- style name and HP bars for each unit
- implement `DOMUIManager` for syncing DOM UI with unit positions
- migrate engine to use `DOMUIManager` and adjust `ShadowEngine`

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687c02aa63e883278cbb1ffb14f85873