### PR TITLE
Add DOM overlay for combat UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,10 @@
             </div>
         </div>
 
-        <canvas id="gameCanvas" class="hidden"></canvas>
+        <div id="canvas-wrapper" class="hidden">
+            <canvas id="gameCanvas"></canvas>
+            <div id="dom-ui-container"></div>
+        </div>
         <div id="hero-panel" class="hidden"></div>
         <div id="battle-log-panel" class="hidden"></div>
     </div>

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -27,8 +27,7 @@ import { CanvasBridgeManager } from './managers/CanvasBridgeManager.js';
 import { SkillIconManager } from './managers/SkillIconManager.js';
 import { StatusIconManager } from './managers/StatusIconManager.js';
 import { BindingManager } from './managers/BindingManager.js';
-import { PixiUIOverlay } from './managers/PixiUIOverlay.js';
-import { OffscreenTextManager } from './managers/OffscreenTextManager.js';
+import { DOMUIManager } from './managers/DOMUIManager.js';
 import { BattleCalculationManager } from './managers/BattleCalculationManager.js';
 import { MercenaryPanelManager } from './managers/MercenaryPanelManager.js';
 import { RuleManager } from './managers/RuleManager.js';
@@ -120,6 +119,7 @@ export class GameEngine {
         this.eventManager.subscribe(GAME_EVENTS.CRITICAL_ERROR, this._handleCriticalError.bind(this));
 
         this.domEngine = new DOMEngine(this.eventManager);
+        this.domUIManager = new DOMUIManager(this);
         this.judgementManager = new JudgementManager(this.eventManager);
         this.stackEngine = new StackEngine(this.eventManager);
         this.guardianManager = new GuardianManager();
@@ -166,24 +166,10 @@ export class GameEngine {
         this.battleSimulationManager.animationManager = this.animationManager;
         this.animationManager.battleSimulationManager = this.battleSimulationManager;
 
-        this.offscreenTextManager = new OffscreenTextManager();
-
-        // Pixi 기반 UI 오버레이를 먼저 생성합니다.
-        this.pixiUIOverlay = new PixiUIOverlay(
-            this.renderer,
-            this.measureManager,
-            this.battleSimulationManager,
-            this.animationManager,
-            this.eventManager,
-            this.sceneEngine,
-            this.offscreenTextManager
-        );
-
-        // 그림자 엔진은 PixiUIOverlay를 활용하도록 변경합니다.
         this.shadowEngine = new ShadowEngine(
             this.battleSimulationManager,
             this.animationManager,
-            this.pixiUIOverlay
+            this.renderer
         );
 
         // 6. UI, Input, Log & Other Managers
@@ -419,7 +405,7 @@ export class GameEngine {
         this.detailInfoManager.update(deltaTime);
         // 그림자 정보를 먼저 갱신한 뒤 UI 오버레이를 업데이트합니다.
         this.shadowEngine.update(deltaTime);
-        this.pixiUIOverlay.update(deltaTime);
+        this.domUIManager.update();
         const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimulationManager.getGridRenderParameters();
         for (const unit of this.battleSimulationManager.unitsOnGrid) {
             const { drawX, drawY } = this.animationManager.getRenderPosition(unit.id, unit.gridX, unit.gridY, effectiveTileSize, gridOffsetX, gridOffsetY);

--- a/js/managers/DOMEngine.js
+++ b/js/managers/DOMEngine.js
@@ -26,6 +26,8 @@ export class DOMEngine {
         this.registerElement('prev-class-btn', document.getElementById('prev-class-btn'));
         this.registerElement('next-class-btn', document.getElementById('next-class-btn'));
         this.registerElement('gameCanvas', document.getElementById('gameCanvas'));
+        // ✨ 캔버스와 DOM UI 컨테이너를 함께 감싸는 래퍼 등록
+        this.registerElement('canvas-wrapper', document.getElementById('canvas-wrapper'));
         this.registerElement('battle-log-panel', document.getElementById('battle-log-panel'));
         this.registerElement('hero-panel', document.getElementById('hero-panel'));
         this.registerElement('battleStartHtmlBtn', document.getElementById('battleStartHtmlBtn'));
@@ -42,6 +44,7 @@ export class DOMEngine {
         const tavernIcon = this.getElement('tavern-icon-btn');
         const territory = this.getElement('territory-screen');
         const tavernScreen = this.getElement('tavern-screen');
+        const canvasWrapper = this.getElement('canvas-wrapper');
         const gameCanvas = this.getElement('gameCanvas');
         const logPanel = this.getElement('battle-log-panel');
         const battleStartBtn = this.getElement('battleStartHtmlBtn');
@@ -56,7 +59,7 @@ export class DOMEngine {
             heroPanelBtn?.classList.remove('hidden');
 
             tavernScreen?.classList.add('hidden');
-            gameCanvas?.classList.add('hidden');
+            canvasWrapper?.classList.add('hidden');
             logPanel?.classList.add('hidden');
         } else if (sceneName === UI_STATES.TAVERN_SCREEN) {
             tavernScreen?.classList.remove('hidden');
@@ -67,7 +70,7 @@ export class DOMEngine {
             recruitBtn?.classList.add('hidden');
             heroPanelBtn?.classList.add('hidden');
 
-            gameCanvas?.classList.add('hidden');
+            canvasWrapper?.classList.add('hidden');
             logPanel?.classList.add('hidden');
         } else { // COMBAT_SCREEN
             territory?.classList.add('hidden');
@@ -77,7 +80,7 @@ export class DOMEngine {
             heroPanelBtn?.classList.add('hidden');
 
             tavernScreen?.classList.add('hidden');
-            gameCanvas?.classList.remove('hidden');
+            canvasWrapper?.classList.remove('hidden');
             logPanel?.classList.remove('hidden');
         }
     }

--- a/js/managers/DOMUIManager.js
+++ b/js/managers/DOMUIManager.js
@@ -1,0 +1,81 @@
+// js/managers/DOMUIManager.js
+
+import { UI_STATES, ATTACK_TYPES } from '../constants.js';
+
+export class DOMUIManager {
+    constructor(gameEngine) {
+        console.log('DOMUIManager: Initialized.');
+        this.battleSimManager = gameEngine.getBattleSimulationManager();
+        this.cameraEngine = gameEngine.getCameraEngine();
+        this.sceneEngine = gameEngine.getSceneEngine();
+        this.animationManager = gameEngine.getAnimationManager();
+
+        this.uiContainer = document.getElementById('dom-ui-container');
+        this.unitElements = new Map(); // key: unitId, value: { wrapper, hpBar, name }
+    }
+
+    _createUnitElement(unit) {
+        const element = document.createElement('div');
+        element.className = 'unit-ui';
+
+        const name = document.createElement('div');
+        name.className = 'unit-name';
+        name.textContent = unit.name;
+        name.style.backgroundColor = unit.type === ATTACK_TYPES.MERCENARY ? 'blue' : 'red';
+
+        const hpBar = document.createElement('div');
+        hpBar.className = 'hp-bar';
+
+        const hpBarCurrent = document.createElement('div');
+        hpBarCurrent.className = 'hp-bar-current';
+
+        hpBar.appendChild(hpBarCurrent);
+        element.appendChild(name);
+        element.appendChild(hpBar);
+
+        this.uiContainer.appendChild(element);
+
+        this.unitElements.set(unit.id, { wrapper: element, hpBar: hpBarCurrent, name: name });
+    }
+
+    update() {
+        if (this.sceneEngine.getCurrentSceneName() !== UI_STATES.COMBAT_SCREEN) {
+            this.uiContainer.style.display = 'none';
+            return;
+        }
+
+        this.uiContainer.style.display = 'block';
+
+        const aliveUnitIds = new Set(this.battleSimManager.unitsOnGrid.filter(u => u.currentHp > 0).map(u => u.id));
+        const { effectiveTileSize, gridOffsetX, gridOffsetY } = this.battleSimManager.getGridRenderParameters();
+
+        for (const unit of this.battleSimManager.unitsOnGrid) {
+            if (unit.currentHp <= 0) continue;
+
+            if (!this.unitElements.has(unit.id)) {
+                this._createUnitElement(unit);
+            }
+
+            const elements = this.unitElements.get(unit.id);
+            const { wrapper, hpBar } = elements;
+
+            const worldPos = this.animationManager.getRenderPosition(unit.id, unit.gridX, unit.gridY, effectiveTileSize, gridOffsetX, gridOffsetY);
+            const screenX = (worldPos.drawX * this.cameraEngine.zoom) + this.cameraEngine.x;
+            const screenY = (worldPos.drawY * this.cameraEngine.zoom) + this.cameraEngine.y;
+
+            const finalX = screenX + (effectiveTileSize * this.cameraEngine.zoom / 2);
+            const finalY = screenY + (effectiveTileSize * this.cameraEngine.zoom);
+
+            wrapper.style.transform = `translate(-50%, 0) translate(${finalX}px, ${finalY}px) scale(${this.cameraEngine.zoom})`;
+
+            hpBar.style.width = `${(unit.currentHp / unit.baseStats.hp) * 100}%`;
+        }
+
+        for (const unitId of this.unitElements.keys()) {
+            if (!aliveUnitIds.has(unitId)) {
+                this.unitElements.get(unitId).wrapper.remove();
+                this.unitElements.delete(unitId);
+            }
+        }
+    }
+}

--- a/js/managers/ShadowEngine.js
+++ b/js/managers/ShadowEngine.js
@@ -1,13 +1,13 @@
 // js/managers/ShadowEngine.js
 
 import { GAME_DEBUG_MODE } from '../constants.js';
-// Use the same CDN build of Pixi.js as the PixiUIOverlay to avoid module
-// resolution issues when running without a bundler.
+// Use the same CDN build of Pixi.js as the previous overlay to avoid module resolution issues
+// when running without a bundler.
 import * as PIXI from 'https://cdn.jsdelivr.net/npm/pixi.js@7/dist/pixi.mjs';
 
 export class ShadowEngine {
-    constructor(battleSimulationManager, animationManager, pixiUIOverlay) {
-        if (!battleSimulationManager || !animationManager || !pixiUIOverlay) {
+    constructor(battleSimulationManager, animationManager, renderer) {
+        if (!battleSimulationManager || !animationManager || !renderer) {
             throw new Error('[ShadowEngine] Missing essential dependencies.');
         }
         if (GAME_DEBUG_MODE) {
@@ -15,8 +15,19 @@ export class ShadowEngine {
         }
         this.battleSimulationManager = battleSimulationManager;
         this.animationManager = animationManager;
-        this.pixiApp = pixiUIOverlay.app;
-        this.shadowContainer = pixiUIOverlay.shadowContainer;
+        const view = document.createElement('canvas');
+        view.id = 'shadow-canvas';
+        // 캔버스 바로 위 레이어에 그림자 캔버스를 삽입하여 DOM UI 요소보다 아래에 위치시킵니다.
+        renderer.canvas.parentNode.insertBefore(view, renderer.canvas.nextSibling);
+        this.pixiApp = new PIXI.Application({
+            view,
+            width: renderer.canvas.width / renderer.pixelRatio,
+            height: renderer.canvas.height / renderer.pixelRatio,
+            backgroundAlpha: 0,
+            autoStart: false
+        });
+        this.shadowContainer = new PIXI.Container();
+        this.pixiApp.stage.addChild(this.shadowContainer);
 
         this.shadows = new Map();
         this.shadowsEnabled = true;
@@ -37,6 +48,14 @@ export class ShadowEngine {
             console.log(`[ShadowEngine] Toggled shadows to: ${this.shadowsEnabled}.`);
         }
         return this.shadowsEnabled;
+    }
+
+    resize(width, height) {
+        this.pixiApp.renderer.resize(width, height);
+    }
+
+    draw() {
+        this.pixiApp.render();
     }
 
     update() {

--- a/style.css
+++ b/style.css
@@ -67,6 +67,62 @@ canvas {
     aspect-ratio: 16 / 9;
 }
 
+/* ✨ 캔버스 래퍼: 캔버스와 DOM UI의 위치 기준점이 됩니다. */
+#canvas-wrapper {
+    position: relative;
+}
+
+/* ✨ DOM UI 컨테이너: 캔버스 위에 투명하게 떠 있도록 설정합니다. */
+#dom-ui-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+/* 개별 유닛 UI 요소 (이름표 + 체력바)의 기본 스타일 */
+.unit-ui {
+    position: absolute;
+    top: -5px;
+    left: 0;
+    transform-origin: center top;
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: center;
+    gap: 2px;
+    will-change: transform;
+}
+
+.unit-name {
+    color: white;
+    font-size: 14px;
+    font-family: "Nanum Gothic", Arial, sans-serif;
+    font-weight: bold;
+    padding: 2px 8px;
+    border-radius: 4px;
+    text-shadow: 1px 1px 2px black;
+    white-space: nowrap;
+}
+
+.hp-bar {
+    width: 60px;
+    height: 8px;
+    background-color: rgba(0, 0, 0, 0.7);
+    border: 1px solid #222;
+    border-radius: 4px;
+}
+
+.hp-bar-current {
+    width: 100%;
+    height: 100%;
+    background-color: #28a745;
+    border-radius: 3px;
+    transition: width 0.2s ease;
+}
+
 /* ✨ HTML 전투 시작 버튼 스타일 */
 .game-button {
     background-color: darkgreen;
@@ -243,8 +299,3 @@ canvas {
     transform: scale(1.1);
 }
 
-/* \u2728 Pixi.js UI \uc624\ubc84\ub808\uc774 \ucee4\ube14\ub9ac\uc2a4\ub97c \uc704\ud55c \uc2a4\ud0c0\uc77c \ucd94\uac00 */
-#pixi-ui-canvas {
-    background-color: transparent !important;
-    border: none !important;
-}


### PR DESCRIPTION
## Summary
- allow DOM elements over the canvas with a new wrapper
- style name and HP bars for each unit
- implement `DOMUIManager` for syncing DOM UI with unit positions
- migrate engine to use `DOMUIManager` and adjust `ShadowEngine`
- show/hide the new canvas wrapper correctly
- insert the shadow canvas below DOM overlays

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687c02aa63e883278cbb1ffb14f85873