### PR TITLE
Update overlay UI placement

### DIFF
--- a/js/managers/PixiUIOverlay.js
+++ b/js/managers/PixiUIOverlay.js
@@ -114,7 +114,8 @@ export class PixiUIOverlay {
                 // 캔버스는 이미 렌더링 완료된 상태이므로 바로 텍스처로 변환합니다.
                 const texture = PIXI.Texture.from(nameCanvas);
                 nameSprite = new PIXI.Sprite(texture);
-                nameSprite.anchor.set(0, 0.5);
+                // 이름표를 타일 하단 중앙 기준으로 배치하기 위해 앵커를 중앙 상단으로 설정
+                nameSprite.anchor.set(0.5, 0);
                 // OffscreenTextManager의 렌더링 스케일만큼 다시 줄여 원래 크기로 맞춥니다.
                 nameSprite.scale.set(1 / this.offscreenTextManager.renderScale);
                 this.uiContainer.addChild(nameSprite);
@@ -128,13 +129,15 @@ export class PixiUIOverlay {
             const { drawX, drawY } = this.animationManager.getRenderPosition(unit.id, unit.gridX, unit.gridY, effectiveTileSize, gridOffsetX, gridOffsetY);
             const centerX = drawX + effectiveTileSize / 2;
 
-            // 이름표를 HP 바 안 왼쪽에 배치
+            // 이름표를 유닛 이미지 바로 아래 중앙에 배치
+            nameSprite.anchor.set(0.5, 0);
+            const nameYPosition = drawY + effectiveTileSize + 5;
+            nameSprite.position.set(centerX, nameYPosition);
+
+            // HP 바 위치를 유닛 위쪽으로 조정해 이름표와 겹치지 않게 함
             const barWidth = effectiveTileSize * 0.8;
             const barHeight = effectiveTileSize * 0.1;
-            const barYOffset = drawY + effectiveTileSize - barHeight;
-            const nameXPosition = centerX - barWidth / 2 + 2;
-            const nameYPosition = barYOffset + barHeight / 2;
-            nameSprite.position.set(nameXPosition, nameYPosition);
+            const barYOffset = drawY - barHeight - 5;
             // HP 바 로직
             const maxHp = unit.baseStats?.hp || 1;
             const hpRatio = Math.max(0, unit.currentHp / maxHp);


### PR DESCRIPTION
## Summary
- reposition unit name sprite under the unit sprite
- shift HP bar above the unit to avoid overlapping

## Testing
- `npm test`
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687c713b8e608327aa88a69c15a0ee15