### PR TITLE
Add canvas unit name labels

### DIFF
--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -60,6 +60,10 @@ export class MeasureManager {
                 barrierBarHeightRatio: 0.05, // 배리어 바 높이 (타일 크기의 5%)
                 barrierBarVerticalOffset: 8, // 배리어 바 수직 오프셋 (픽셀)
 
+                // 유닛 이름표 관련
+                unitNameFontSizeRatio: 0.18, // 이름표 폰트 크기 비율
+                unitNameVerticalOffset: 5,   // 이름표 수직 오프셋 (픽셀)
+
                 // 데미지 숫자 팝업 관련
                 damageNumberDuration: 1000,     // 데미지 숫자 팝업 지속 시간 (ms)
                 damageNumberFloatSpeed: 0.05,   // 데미지 숫자 부유 속도

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -306,6 +306,24 @@ export class VFXManager {
     }
 
     /**
+     * 유닛 이름을 스프라이트 하단에 그립니다.
+     * @param {CanvasRenderingContext2D} ctx
+     * @param {object} unit
+     * @param {number} effectiveTileSize
+     * @param {number} actualDrawX
+     * @param {number} actualDrawY
+     */
+    drawUnitName(ctx, unit, effectiveTileSize, actualDrawX, actualDrawY) {
+        const fontSize = effectiveTileSize * this.measureManager.get('vfx.unitNameFontSizeRatio');
+        const offsetY = effectiveTileSize + this.measureManager.get('vfx.unitNameVerticalOffset');
+        ctx.fillStyle = '#FFFFFF';
+        ctx.font = `bold ${fontSize}px Arial`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        ctx.fillText(unit.name, actualDrawX + effectiveTileSize / 2, actualDrawY + offsetY);
+    }
+
+    /**
      * 모든 활성 시각 효과를 그립니다. 이 메서드는 LayerEngine에 의해 호출됩니다.
      * @param {CanvasRenderingContext2D} ctx - 캔버스 2D 렌더링 컨텍스트
      */
@@ -350,6 +368,7 @@ export class VFXManager {
             // if (GAME_DEBUG_MODE) console.log(`[VFXManager Debug] Unit ${unit.id} (HP/Barrier Bar): drawX=${drawX.toFixed(2)}, drawY=${drawY.toFixed(2)}`);
             this.drawHpBar(ctx, unit, effectiveTileSize, drawX, drawY);
             this.drawBarrierBar(ctx, unit, effectiveTileSize, drawX, drawY); // ✨ 배리어 바 그리기 호출
+            this.drawUnitName(ctx, unit, effectiveTileSize, drawX, drawY);
 
             if (this.bleedIcon && this.bleedingUnits.has(unit.id)) {
                 const iconSize = effectiveTileSize * 0.3;

--- a/tests/unit/vfxManagerUnitTests.js
+++ b/tests/unit/vfxManagerUnitTests.js
@@ -156,7 +156,23 @@ export function runVFXManagerUnitTests() {
         console.error("VFXManager: Error during draw method test. [FAIL]", e);
     }
 
-    // 테스트 6: 이벤트 매니저를 통한 damageNumberDisplay 연동 확인 (간접적)
+    // 테스트 6: drawUnitName을 통한 이름표 그리기 확인
+    testCount++;
+    try {
+        const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);
+        mockCtx.fillTextCalled = false;
+        vfxManager.draw(mockCtx);
+        if (mockCtx.fillTextCalled) {
+            console.log("VFXManager: drawUnitName drew unit name. [PASS]");
+            passCount++;
+        } else {
+            console.error("VFXManager: drawUnitName did not draw unit name. [FAIL]");
+        }
+    } catch (e) {
+        console.error("VFXManager: Error during drawUnitName test. [FAIL]", e);
+    }
+
+    // 테스트 7: 이벤트 매니저를 통한 damageNumberDisplay 연동 확인 (간접적)
     testCount++;
     try {
         const vfxManager = new VFXManager(mockRenderer, mockMeasureManager, mockCameraEngine, mockBattleSimulationManager, mockAnimationManager, mockEventManager);


### PR DESCRIPTION
## Summary
- allow VFXManager to draw unit names under each unit
- expose measurement controls for name rendering
- cover drawing unit names in unit tests

## Testing
- `npm test`
- `python3 -m http.server 8000 & curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d4dc41d5c8327994d75277feadc11