### PR TITLE
Add colored unit name tags

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -77,4 +77,9 @@ export const SKILL_TYPE_COLORS = {
     [SKILL_TYPES.PASSIVE]: 'green'
 };
 
+export const UNIT_NAME_BG_COLORS = {
+    [ATTACK_TYPES.MERCENARY]: 'rgba(0,0,255,0.5)',
+    [ATTACK_TYPES.ENEMY]: 'rgba(255,0,0,0.5)'
+};
+
 export const GAME_DEBUG_MODE = true; // ✨ 디버그 모드 플래그 (배포 시 false로 설정)

--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -61,7 +61,7 @@ export class MeasureManager {
                 barrierBarVerticalOffset: 8, // 배리어 바 수직 오프셋 (픽셀)
 
                 // 유닛 이름표 관련
-                unitNameFontSizeRatio: 0.18, // 이름표 폰트 크기 비율
+                unitNameFontSizeRatio: 0.15, // 이름표 폰트 크기 비율 (조금 더 작게)
                 unitNameVerticalOffset: 5,   // 이름표 수직 오프셋 (픽셀)
 
                 // 데미지 숫자 팝업 관련

--- a/js/managers/PixiUIOverlay.js
+++ b/js/managers/PixiUIOverlay.js
@@ -1,5 +1,5 @@
 import * as PIXI from 'https://cdn.jsdelivr.net/npm/pixi.js@7/dist/pixi.mjs';
-import { GAME_DEBUG_MODE, GAME_EVENTS, ATTACK_TYPES, UI_STATES, SKILL_TYPE_COLORS } from '../constants.js';
+import { GAME_DEBUG_MODE, GAME_EVENTS, ATTACK_TYPES, UI_STATES, SKILL_TYPE_COLORS, UNIT_NAME_BG_COLORS } from '../constants.js';
 
 export class PixiUIOverlay {
     // OffscreenTextManager를 생성자에서 받습니다.
@@ -108,8 +108,10 @@ export class PixiUIOverlay {
                 // [디버그 1] 이름표가 '생성'되는 시점을 확인합니다.
                 console.log(`[디버그] ${unit.name}의 이름표를 새로 생성합니다.`);
 
-                const bgColor = 'rgba(0,0,0,0)';
-                const fontSize = Math.round(effectiveTileSize * 0.18);
+                const bgColor = UNIT_NAME_BG_COLORS[unit.type] || 'rgba(0,0,0,0)';
+                const fontSize = Math.round(
+                    effectiveTileSize * this.measureManager.get('vfx.unitNameFontSizeRatio')
+                );
 
                 // OffscreenTextManager로부터 캔버스를 받아 텍스처를 생성합니다.
                 const nameCanvas = this.offscreenTextManager.getOrCreateText(unit.name, { fontSize: fontSize, bgColor: bgColor });
@@ -137,7 +139,7 @@ export class PixiUIOverlay {
 
             // 이름표를 유닛 이미지 바로 아래 중앙에 배치
             nameSprite.anchor.set(0.5, 0);
-            const nameYPosition = drawY + effectiveTileSize + 5;
+            const nameYPosition = drawY + effectiveTileSize + this.measureManager.get('vfx.unitNameVerticalOffset');
             nameSprite.position.set(centerX, nameYPosition);
 
             // [디버그 3] 매 프레임 이름표의 '위치'와 '상태'를 확인합니다.


### PR DESCRIPTION
## Summary
- shrink unit name tag font size via MeasureManager
- add background color constants for ally and enemy name tags
- render unit name tags using new measurements and colors

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d502b2cb083278432c6d798bb055e