### PR TITLE
Implement hero detail overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,21 @@
         <canvas id="gameCanvas" class="hidden"></canvas>
         <div id="hero-panel" class="hidden"></div>
         <div id="battle-log-panel" class="hidden"></div>
+        <div id="hero-detail-overlay" class="hidden">
+            <div id="hero-detail-container">
+                <div id="hero-detail-left">
+                    <img id="hero-detail-portrait" src="" alt="hero portrait">
+                    <div id="hero-detail-stats"></div>
+                    <div id="hero-detail-traits"></div>
+                    <div id="hero-detail-synergies"></div>
+                </div>
+                <div id="hero-detail-right">
+                    <div id="hero-detail-equipment"></div>
+                    <div id="hero-detail-skills"></div>
+                </div>
+                <button id="hero-detail-close-btn">닫기</button>
+            </div>
+        </div>
     </div>
     <button id="toggleHeroPanelBtn" style="position: absolute; top: 10px; right: 10px; z-index: 100;">영웅 패널</button>
     <!-- ✨ 캔버스 버튼 외에 별도의 HTML 전투 시작 버튼 -->

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -98,6 +98,7 @@ import { TerritoryUIManager } from './managers/TerritoryUIManager.js';
 import { TerritorySceneManager } from './managers/TerritorySceneManager.js';
 import { TerritoryGridManager } from './managers/TerritoryGridManager.js';
 import { TavernManager } from './managers/TavernManager.js';
+import { HeroDetailedUIManager } from './managers/HeroDetailedUIManager.js';
 import { GAME_EVENTS, UI_STATES, BUTTON_IDS, ATTACK_TYPES, GAME_DEBUG_MODE } from './constants.js';
 
 import { UNITS } from '../data/unit.js';
@@ -297,7 +298,8 @@ export class GameEngine {
         this.territoryBackgroundManager = new TerritoryBackgroundManager(this.domEngine);
         this.territoryUIManager = new TerritoryUIManager(this.eventManager, this.domEngine);
         this.territoryGridManager = new TerritoryGridManager(this.domEngine);
-        this.tavernManager = new TavernManager(this.domEngine, this.sceneEngine, this.uiEngine, this.heroManager);
+        this.heroDetailedUIManager = new HeroDetailedUIManager(this.domEngine);
+        this.tavernManager = new TavernManager(this.domEngine, this.sceneEngine, this.uiEngine, this.heroManager, this.heroDetailedUIManager);
 
         // --- LAYER REGISTRATION ---
         this.layerEngine.registerLayer('combatScene', (ctx) => {
@@ -579,4 +581,5 @@ export class GameEngine {
     getHideAndSeekManager() { return this.hideAndSeekManager; }
     getDOMEngine() { return this.domEngine; }
     getTavernManager() { return this.tavernManager; }
+    getHeroDetailedUIManager() { return this.heroDetailedUIManager; }
 }

--- a/js/managers/DOMEngine.js
+++ b/js/managers/DOMEngine.js
@@ -30,6 +30,14 @@ export class DOMEngine {
         this.registerElement('hero-panel', document.getElementById('hero-panel'));
         this.registerElement('battleStartHtmlBtn', document.getElementById('battleStartHtmlBtn'));
         this.registerElement('recruitWarriorBtn', document.getElementById('recruitWarriorBtn'));
+        this.registerElement('hero-detail-overlay', document.getElementById('hero-detail-overlay'));
+        this.registerElement('hero-detail-portrait', document.getElementById('hero-detail-portrait'));
+        this.registerElement('hero-detail-stats', document.getElementById('hero-detail-stats'));
+        this.registerElement('hero-detail-traits', document.getElementById('hero-detail-traits'));
+        this.registerElement('hero-detail-synergies', document.getElementById('hero-detail-synergies'));
+        this.registerElement('hero-detail-equipment', document.getElementById('hero-detail-equipment'));
+        this.registerElement('hero-detail-skills', document.getElementById('hero-detail-skills'));
+        this.registerElement('hero-detail-close-btn', document.getElementById('hero-detail-close-btn'));
     }
 
     _setupEventListeners() {

--- a/js/managers/HeroDetailedUIManager.js
+++ b/js/managers/HeroDetailedUIManager.js
@@ -1,0 +1,87 @@
+import { WARRIOR_SKILLS } from "../../data/warriorSkills.js";
+export class HeroDetailedUIManager {
+    constructor(domEngine) {
+        this.domEngine = domEngine;
+        this.overlay = domEngine.getElement('hero-detail-overlay');
+        this.portraitImg = domEngine.getElement('hero-detail-portrait');
+        this.statsEl = domEngine.getElement('hero-detail-stats');
+        this.traitsEl = domEngine.getElement('hero-detail-traits');
+        this.synergiesEl = domEngine.getElement('hero-detail-synergies');
+        this.equipmentEl = domEngine.getElement('hero-detail-equipment');
+        this.skillsEl = domEngine.getElement('hero-detail-skills');
+        this.closeBtn = domEngine.getElement('hero-detail-close-btn');
+        this.closeBtn?.addEventListener('click', () => this.hide());
+    }
+
+    show(heroData) {
+        if (!this.overlay || !heroData) return;
+        this._populateLeft(heroData);
+        this._populateRight(heroData);
+        this.overlay.classList.remove('hidden');
+    }
+
+    hide() {
+        this.overlay?.classList.add('hidden');
+    }
+
+    _populateLeft(hero) {
+        const portrait = this._getPortrait(hero.classId);
+        if (this.portraitImg) {
+            this.portraitImg.src = portrait;
+            this.portraitImg.alt = hero.name;
+        }
+        if (this.statsEl) {
+            const s = hero.baseStats || {};
+            this.statsEl.innerHTML = `
+                <p>HP: ${hero.currentHp ?? s.hp}/${s.hp ?? '?'}</p>
+                <p>공격: ${s.attack ?? 0} 방어: ${s.defense ?? 0}</p>
+                <p>속도: ${s.speed ?? 0}</p>
+                <p>무게: ${s.weight ?? 0} 용맹: ${s.valor ?? 0}</p>`;
+        }
+        if (this.traitsEl) this.traitsEl.textContent = '특성: (미구현)';
+        if (this.synergiesEl) this.synergiesEl.textContent = '시너지: (미구현)';
+    }
+
+    _populateRight(hero) {
+        if (this.equipmentEl) {
+            this.equipmentEl.innerHTML = '';
+            for (let i = 0; i < 5; i++) {
+                const slot = document.createElement('div');
+                slot.className = 'equipment-slot';
+                this.equipmentEl.appendChild(slot);
+            }
+        }
+        if (this.skillsEl) {
+            this.skillsEl.innerHTML = '';
+            const skills = hero.skillSlots || [];
+            for (const skillId of skills) {
+                const skillData = Object.values(WARRIOR_SKILLS).find(s => s.id === skillId) || null;
+                const iconPath = skillData?.icon;
+                const div = document.createElement('div');
+                div.className = 'skill-entry';
+                if (iconPath) {
+                    const img = document.createElement('img');
+                    img.src = iconPath;
+                    img.alt = skillData.name;
+                    img.title = skillData.description || '';
+                    div.appendChild(img);
+                }
+                const span = document.createElement('span');
+                span.textContent = skillData?.name || skillId;
+                div.appendChild(span);
+                this.skillsEl.appendChild(div);
+            }
+        }
+    }
+
+    _getPortrait(classId) {
+        switch (classId) {
+            case 'class_warrior':
+                return 'assets/territory/warrior-ui.png';
+            case 'class_gunner':
+                return 'assets/territory/gunner-ui.png';
+            default:
+                return 'assets/territory/warrior-ui.png';
+        }
+    }
+}

--- a/js/managers/TavernManager.js
+++ b/js/managers/TavernManager.js
@@ -1,12 +1,13 @@
 import { GAME_DEBUG_MODE, UI_STATES } from '../constants.js';
 
 export class TavernManager {
-    constructor(domEngine, sceneEngine, uiEngine, heroManager) {
+    constructor(domEngine, sceneEngine, uiEngine, heroManager, heroDetailedUIManager) {
         if (GAME_DEBUG_MODE) console.log('🍻 TavernManager initialized.');
         this.domEngine = domEngine;
         this.sceneEngine = sceneEngine;
         this.uiEngine = uiEngine;
         this.heroManager = heroManager;
+        this.heroDetailedUIManager = heroDetailedUIManager;
 
         // ✨ 고용 가능한 직업 및 관련 이미지 정보
         this.availableClasses = ['warrior', 'gunner', 'mage'];
@@ -95,10 +96,13 @@ export class TavernManager {
         this._updateHireUI();
     }
 
-    hireSelectedHero() {
+    async hireSelectedHero() {
         const currentClass = this.availableClasses[this.currentClassIndex];
         if (GAME_DEBUG_MODE) console.log(`Attempting to hire a ${currentClass}.`);
-        alert(`${currentClass}(을)를 고용합니다! (실제 고용 로직은 추후 구현)`);
+        let classId = 'class_warrior';
+        if (currentClass === 'gunner') classId = 'class_gunner';
+        const hero = await this.heroManager.heroEngine.generateHero({ classId });
         this.closeHireUI();
+        this.heroDetailedUIManager?.show(hero);
     }
 }

--- a/style.css
+++ b/style.css
@@ -257,3 +257,54 @@ canvas {
     border: none !important;
     z-index: 2; /* 메인 캔버스 위에 오도록 높은 값 지정 */
 }
+
+/* Hero Detail Overlay */
+#hero-detail-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 30;
+}
+
+#hero-detail-container {
+    background-color: #222;
+    border: 2px solid #555;
+    border-radius: 10px;
+    width: 70%;
+    height: 60%;
+    display: flex;
+    padding: 20px;
+    box-sizing: border-box;
+    color: white;
+}
+
+#hero-detail-left, #hero-detail-right {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#hero-detail-equipment .equipment-slot {
+    width: 48px;
+    height: 48px;
+    border: 1px solid #888;
+    margin-bottom: 5px;
+}
+
+.skill-entry {
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+.skill-entry img {
+    width: 32px;
+    height: 32px;
+    margin-right: 5px;
+}


### PR DESCRIPTION
## Summary
- add HeroDetailedUIManager to show hired hero information
- display overlay with portrait, stats and placeholder sections
- show hero skills with simple tooltip
- connect new UI manager with TavernManager
- update DOM registrations, GameEngine setup, and styling

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687de2de33fc832795002d23ead610c4