### PR TITLE
Update UI positions for health, buffs, and names

### DIFF
--- a/js/managers/StatusIconManager.js
+++ b/js/managers/StatusIconManager.js
@@ -25,8 +25,7 @@ export class StatusIconManager {
         this.turnCountManager = turnCountManager;
 
         this.iconSizeRatio = 0.2;
-        // 아이콘은 HP 바 아래 한 곳에만 표시되도록 오프셋을 낮춥니다.
-        this.iconOffsetYRatio = 0.1;
+        // 아이콘을 유닛 오른쪽에 세로로 배치합니다.
         this.iconSpacing = 5;
     }
 
@@ -48,8 +47,8 @@ export class StatusIconManager {
             const { renderX: drawX, renderY: drawY } = bindings;
 
             const baseIconSize = effectiveTileSize * this.iconSizeRatio;
-            let currentIconDrawX = drawX + (effectiveTileSize - (activeEffects.size * baseIconSize + (activeEffects.size - 1) * this.iconSpacing)) / 2;
-            const iconDrawY = drawY - (effectiveTileSize * this.iconOffsetYRatio);
+            const iconDrawX = drawX + effectiveTileSize + this.iconSpacing;
+            let currentIconDrawY = drawY + (effectiveTileSize - (activeEffects.size * baseIconSize + (activeEffects.size - 1) * this.iconSpacing)) / 2;
 
             for (const [effectId, effectDataWrapper] of activeEffects.entries()) {
                 const icon = this.skillIconManager.getSkillIcon(effectId);
@@ -58,13 +57,13 @@ export class StatusIconManager {
                     if (effectDataWrapper.effectData.type === STATUS_EFFECT_TYPES.DEBUFF) {
                         ctx.strokeStyle = 'red';
                         ctx.lineWidth = 2;
-                        ctx.strokeRect(currentIconDrawX, iconDrawY, baseIconSize, baseIconSize);
+                        ctx.strokeRect(iconDrawX, currentIconDrawY, baseIconSize, baseIconSize);
                     } else if (effectDataWrapper.effectData.type === STATUS_EFFECT_TYPES.BUFF) {
                         ctx.strokeStyle = 'green';
                         ctx.lineWidth = 2;
-                        ctx.strokeRect(currentIconDrawX, iconDrawY, baseIconSize, baseIconSize);
+                        ctx.strokeRect(iconDrawX, currentIconDrawY, baseIconSize, baseIconSize);
                     }
-                    ctx.drawImage(icon, currentIconDrawX, iconDrawY, baseIconSize, baseIconSize);
+                    ctx.drawImage(icon, iconDrawX, currentIconDrawY, baseIconSize, baseIconSize);
                     ctx.restore();
 
                     if (effectDataWrapper.turnsRemaining !== -1) {
@@ -75,14 +74,14 @@ export class StatusIconManager {
                         ctx.textBaseline = 'bottom';
                         ctx.strokeStyle = 'black';
                         ctx.lineWidth = 2;
-                        const textX = currentIconDrawX + baseIconSize / 2;
-                        const textY = iconDrawY + baseIconSize;
+                        const textX = iconDrawX + baseIconSize / 2;
+                        const textY = currentIconDrawY + baseIconSize;
                         ctx.strokeText(effectDataWrapper.turnsRemaining.toString(), textX, textY);
                         ctx.fillText(effectDataWrapper.turnsRemaining.toString(), textX, textY);
                         ctx.restore();
                     }
 
-                    currentIconDrawX += baseIconSize + this.iconSpacing;
+                    currentIconDrawY += baseIconSize + this.iconSpacing;
                 }
             }
         }

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -260,10 +260,10 @@ export class VFXManager {
 
         const barWidth = effectiveTileSize * this.measureManager.get('vfx.hpBarWidthRatio');
         const barHeight = effectiveTileSize * this.measureManager.get('vfx.hpBarHeightRatio');
-        const barOffsetY = -(barHeight + this.measureManager.get('vfx.hpBarVerticalOffset')); // 유닛 이미지 위에 위치
 
-        const hpBarDrawX = actualDrawX + (effectiveTileSize - barWidth) / 2;
-        const hpBarDrawY = actualDrawY + barOffsetY;
+        // HP 바를 유닛 왼쪽에 세로 중앙 정렬로 배치
+        const hpBarDrawX = actualDrawX - barWidth - this.measureManager.get('vfx.hpBarVerticalOffset');
+        const hpBarDrawY = actualDrawY + (effectiveTileSize - barHeight) / 2;
 
         ctx.fillStyle = 'rgba(50, 50, 50, 0.8)';
         ctx.fillRect(hpBarDrawX, hpBarDrawY, barWidth, barHeight);
@@ -293,13 +293,12 @@ export class VFXManager {
         const maxBarrier = unit.maxBarrier;
         const barrierRatio = maxBarrier > 0 ? currentBarrier / maxBarrier : 0;
 
-        // HP 바와 동일한 위치와 크기로 계산하여 정확히 겹치도록 합니다
+        // HP 바와 동일한 크기로 계산하되 위치는 좌측에 맞춥니다
         const barWidth = effectiveTileSize * this.measureManager.get('vfx.hpBarWidthRatio');
         const barHeight = effectiveTileSize * this.measureManager.get('vfx.hpBarHeightRatio');
-        const barOffsetY = -(barHeight + this.measureManager.get('vfx.hpBarVerticalOffset'));
 
-        const barrierBarDrawX = actualDrawX + (effectiveTileSize - barWidth) / 2;
-        const barrierBarDrawY = actualDrawY + barOffsetY;
+        const barrierBarDrawX = actualDrawX - barWidth - this.measureManager.get('vfx.hpBarVerticalOffset');
+        const barrierBarDrawY = actualDrawY + (effectiveTileSize - barHeight) / 2;
 
         // 노란색 배리어 바를 HP 바 위에 덧씌움 (배경과 테두리는 없음)
         ctx.fillStyle = '#FFFF00';
@@ -307,7 +306,7 @@ export class VFXManager {
     }
 
     /**
-     * 유닛 이름을 스프라이트 하단에 그립니다.
+     * 유닛 이름을 스프라이트 상단에 그립니다.
      * @param {CanvasRenderingContext2D} ctx
      * @param {object} unit
      * @param {number} effectiveTileSize
@@ -316,7 +315,7 @@ export class VFXManager {
      */
     drawUnitName(ctx, unit, effectiveTileSize, actualDrawX, actualDrawY) {
         const fontSize = effectiveTileSize * this.measureManager.get('vfx.unitNameFontSizeRatio');
-        const offsetY = effectiveTileSize + this.measureManager.get('vfx.unitNameVerticalOffset');
+        const offsetY = this.measureManager.get('vfx.unitNameVerticalOffset');
         const bgColor = UNIT_NAME_BG_COLORS[unit.type] || 'rgba(0,0,0,0)';
         const nameCanvas = this.offscreenTextManager.getOrCreateText(unit.name, {
             fontSize,
@@ -327,7 +326,7 @@ export class VFXManager {
         const drawWidth = nameCanvas.width * scale;
         const drawHeight = nameCanvas.height * scale;
         const drawX = actualDrawX + effectiveTileSize / 2 - drawWidth / 2;
-        const drawY = actualDrawY + offsetY;
+        const drawY = actualDrawY - offsetY - drawHeight;
         ctx.drawImage(nameCanvas, drawX, drawY, drawWidth, drawHeight);
     }
 


### PR DESCRIPTION
## Summary
- reposition health and barrier bars to the left side of units
- show name tags above units
- display status icons vertically on the right of units

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687de56ab920832789c381db9860eaa1