### PR TITLE
Adjust combat UI layout

### DIFF
--- a/js/managers/MeasureManager.js
+++ b/js/managers/MeasureManager.js
@@ -54,14 +54,14 @@ export class MeasureManager {
             vfx: {
                 // HP/Barrier Bar 관련
                 hpBarWidthRatio: 0.8,      // HP 바 너비 (타일 크기의 80%)
-                hpBarHeightRatio: 0.1,     // HP 바 높이 (타일 크기의 10%)
+                hpBarHeightRatio: 0.06,    // HP 바 높이 (타일 크기의 6%)
                 hpBarVerticalOffset: 5,    // HP 바 수직 오프셋 (픽셀)
                 barrierBarWidthRatio: 0.8, // 배리어 바 너비 (타일 크기의 80%)
                 barrierBarHeightRatio: 0.05, // 배리어 바 높이 (타일 크기의 5%)
                 barrierBarVerticalOffset: 8, // 배리어 바 수직 오프셋 (픽셀)
 
                 // 유닛 이름표 관련
-                unitNameFontSizeRatio: 0.15, // 이름표 폰트 크기 비율 (조금 더 작게)
+                unitNameFontSizeRatio: 0.12, // 이름표 폰트 크기 비율
                 unitNameVerticalOffset: 5,   // 이름표 수직 오프셋 (픽셀)
 
                 // 데미지 숫자 팝업 관련

--- a/js/managers/OffscreenTextManager.js
+++ b/js/managers/OffscreenTextManager.js
@@ -37,7 +37,7 @@ export class OffscreenTextManager {
         const scaledFontSize = fontSize * this.renderScale;
         const padding = 5 * this.renderScale;
 
-        newCtx.font = `bold ${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
+        newCtx.font = `${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
         const textMetrics = newCtx.measureText(text);
 
         const canvasWidth = textMetrics.width + padding * 2;
@@ -63,7 +63,7 @@ export class OffscreenTextManager {
 
         // 텍스트 그리기
         newCtx.fillStyle = fontColor;
-        newCtx.font = `bold ${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
+        newCtx.font = `${scaledFontSize}px \"Nanum Gothic\", Arial, sans-serif`;
         newCtx.textAlign = 'center';
         newCtx.textBaseline = 'middle';
         newCtx.fillText(text, canvasWidth / 2, canvasHeight / 2);

--- a/js/managers/PixiUIOverlay.js
+++ b/js/managers/PixiUIOverlay.js
@@ -138,9 +138,9 @@ export class PixiUIOverlay {
             const { drawX, drawY } = this.animationManager.getRenderPosition(unit.id, unit.gridX, unit.gridY, effectiveTileSize, gridOffsetX, gridOffsetY);
             const worldCenterX = drawX + effectiveTileSize / 2;
             const worldNameY = drawY + effectiveTileSize + this.measureManager.get('vfx.unitNameVerticalOffset');
-            const barWidth = effectiveTileSize * 0.8;
-            const barHeight = effectiveTileSize * 0.1;
-            const worldBarY = drawY - barHeight - 5;
+            const barWidth = effectiveTileSize * this.measureManager.get('vfx.hpBarWidthRatio');
+            const barHeight = effectiveTileSize * this.measureManager.get('vfx.hpBarHeightRatio');
+            const worldBarY = drawY - barHeight - this.measureManager.get('vfx.hpBarVerticalOffset');
 
             const screenCenter = this.cameraEngine ? this.cameraEngine.worldToScreen(worldCenterX, worldNameY) : { x: worldCenterX, y: worldNameY };
             const barScreenPos = this.cameraEngine ? this.cameraEngine.worldToScreen(worldCenterX, worldBarY) : { x: worldCenterX, y: worldBarY };

--- a/js/managers/StatusIconManager.js
+++ b/js/managers/StatusIconManager.js
@@ -47,8 +47,11 @@ export class StatusIconManager {
             const { renderX: drawX, renderY: drawY } = bindings;
 
             const baseIconSize = effectiveTileSize * this.iconSizeRatio;
-            const iconDrawX = drawX + effectiveTileSize + this.iconSpacing;
-            let currentIconDrawY = drawY + (effectiveTileSize - (activeEffects.size * baseIconSize + (activeEffects.size - 1) * this.iconSpacing)) / 2;
+            const barOffset = this.measureManager.get('vfx.hpBarVerticalOffset');
+
+            // 아이콘을 HP 바 바로 아래 가로 방향으로 배치
+            let currentIconDrawX = drawX + (effectiveTileSize - (activeEffects.size * baseIconSize + (activeEffects.size - 1) * this.iconSpacing)) / 2;
+            const iconDrawY = drawY - barOffset + this.iconSpacing;
 
             for (const [effectId, effectDataWrapper] of activeEffects.entries()) {
                 const icon = this.skillIconManager.getSkillIcon(effectId);
@@ -57,13 +60,13 @@ export class StatusIconManager {
                     if (effectDataWrapper.effectData.type === STATUS_EFFECT_TYPES.DEBUFF) {
                         ctx.strokeStyle = 'red';
                         ctx.lineWidth = 2;
-                        ctx.strokeRect(iconDrawX, currentIconDrawY, baseIconSize, baseIconSize);
+                        ctx.strokeRect(currentIconDrawX, iconDrawY, baseIconSize, baseIconSize);
                     } else if (effectDataWrapper.effectData.type === STATUS_EFFECT_TYPES.BUFF) {
                         ctx.strokeStyle = 'green';
                         ctx.lineWidth = 2;
-                        ctx.strokeRect(iconDrawX, currentIconDrawY, baseIconSize, baseIconSize);
+                        ctx.strokeRect(currentIconDrawX, iconDrawY, baseIconSize, baseIconSize);
                     }
-                    ctx.drawImage(icon, iconDrawX, currentIconDrawY, baseIconSize, baseIconSize);
+                    ctx.drawImage(icon, currentIconDrawX, iconDrawY, baseIconSize, baseIconSize);
                     ctx.restore();
 
                     if (effectDataWrapper.turnsRemaining !== -1) {
@@ -74,14 +77,14 @@ export class StatusIconManager {
                         ctx.textBaseline = 'bottom';
                         ctx.strokeStyle = 'black';
                         ctx.lineWidth = 2;
-                        const textX = iconDrawX + baseIconSize / 2;
-                        const textY = currentIconDrawY + baseIconSize;
+                        const textX = currentIconDrawX + baseIconSize / 2;
+                        const textY = iconDrawY + baseIconSize;
                         ctx.strokeText(effectDataWrapper.turnsRemaining.toString(), textX, textY);
                         ctx.fillText(effectDataWrapper.turnsRemaining.toString(), textX, textY);
                         ctx.restore();
                     }
 
-                    currentIconDrawY += baseIconSize + this.iconSpacing;
+                    currentIconDrawX += baseIconSize + this.iconSpacing;
                 }
             }
         }

--- a/js/managers/VFXManager.js
+++ b/js/managers/VFXManager.js
@@ -261,9 +261,9 @@ export class VFXManager {
         const barWidth = effectiveTileSize * this.measureManager.get('vfx.hpBarWidthRatio');
         const barHeight = effectiveTileSize * this.measureManager.get('vfx.hpBarHeightRatio');
 
-        // HP 바를 유닛 왼쪽에 세로 중앙 정렬로 배치
-        const hpBarDrawX = actualDrawX - barWidth - this.measureManager.get('vfx.hpBarVerticalOffset');
-        const hpBarDrawY = actualDrawY + (effectiveTileSize - barHeight) / 2;
+        // HP 바를 유닛 머리 위 중앙에 배치하도록 위치 계산을 수정
+        const hpBarDrawX = actualDrawX + (effectiveTileSize - barWidth) / 2;
+        const hpBarDrawY = actualDrawY - barHeight - this.measureManager.get('vfx.hpBarVerticalOffset');
 
         ctx.fillStyle = 'rgba(50, 50, 50, 0.8)';
         ctx.fillRect(hpBarDrawX, hpBarDrawY, barWidth, barHeight);
@@ -297,8 +297,8 @@ export class VFXManager {
         const barWidth = effectiveTileSize * this.measureManager.get('vfx.hpBarWidthRatio');
         const barHeight = effectiveTileSize * this.measureManager.get('vfx.hpBarHeightRatio');
 
-        const barrierBarDrawX = actualDrawX - barWidth - this.measureManager.get('vfx.hpBarVerticalOffset');
-        const barrierBarDrawY = actualDrawY + (effectiveTileSize - barHeight) / 2;
+        const barrierBarDrawX = actualDrawX + (effectiveTileSize - barWidth) / 2;
+        const barrierBarDrawY = actualDrawY - barHeight - this.measureManager.get('vfx.hpBarVerticalOffset');
 
         // 노란색 배리어 바를 HP 바 위에 덧씌움 (배경과 테두리는 없음)
         ctx.fillStyle = '#FFFF00';
@@ -326,7 +326,8 @@ export class VFXManager {
         const drawWidth = nameCanvas.width * scale;
         const drawHeight = nameCanvas.height * scale;
         const drawX = actualDrawX + effectiveTileSize / 2 - drawWidth / 2;
-        const drawY = actualDrawY - offsetY - drawHeight;
+        // 이름은 유닛의 발밑에 위치하도록 변경
+        const drawY = actualDrawY + effectiveTileSize + offsetY;
         ctx.drawImage(nameCanvas, drawX, drawY, drawWidth, drawHeight);
     }
 
@@ -411,7 +412,7 @@ export class VFXManager {
             ctx.fillStyle = dmgNum.color || ((dmgNum.damage > 0) ? '#FF4500' : '#00FF00');
             const baseFontSize = this.measureManager.get('vfx.damageNumberBaseFontSize');
             const scaleFactor = this.measureManager.get('vfx.damageNumberScaleFactor');
-            ctx.font = `bold ${baseFontSize + (1 - progress) * scaleFactor}px Arial`;
+            ctx.font = `${baseFontSize + (1 - progress) * scaleFactor}px Arial`;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'bottom';
             ctx.fillText(
@@ -443,7 +444,7 @@ export class VFXManager {
             ctx.save();
             ctx.globalAlpha = alpha;
             ctx.fillStyle = effect.color;
-            ctx.font = `bold ${effectiveTileSize * 0.25}px Arial`;
+            ctx.font = `${effectiveTileSize * 0.25}px Arial`;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'bottom';
             ctx.fillText(


### PR DESCRIPTION
## Summary
- refine combat UI layout and fonts
- center HP/barrier bars above unit heads
- draw buff icons below the HP bar
- move nameplates below feet
- make fonts slimmer and HP bar thinner

## Testing
- `npm test`
- `python3 -m http.server 8000 &` then `curl http://localhost:8000/debug.html | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_687f4b5b50e88327a03905a15e06f535