### PR TITLE
Fix portrait display and scale tavern grid

### DIFF
--- a/js/managers/HeroDetailedUIManager.js
+++ b/js/managers/HeroDetailedUIManager.js
@@ -29,8 +29,13 @@ export class HeroDetailedUIManager {
     _populateLeft(hero, stats) {
         const portrait = this._getPortrait(hero.classId);
         if (this.portraitImg) {
-            this.portraitImg.src = portrait;
-            this.portraitImg.alt = hero.name;
+            if (this.portraitImg.tagName === 'IMG') {
+                this.portraitImg.src = portrait;
+                this.portraitImg.alt = hero.name;
+            } else {
+                this.portraitImg.style.backgroundImage = `url(${portrait})`;
+                this.portraitImg.title = hero.name;
+            }
         }
         if (this.statsEl) {
             const s = stats || {};

--- a/style.css
+++ b/style.css
@@ -182,6 +182,8 @@ canvas {
     grid-template-rows: repeat(2, 1fr);
     width: 80%;
     height: 60%;
+    transform: scale(0.33);
+    transform-origin: center;
     gap: 20px;
 }
 


### PR DESCRIPTION
## Summary
- show hero portraits by using background images when the element isn't an `<img>`
- shrink the tavern screen grid to one-third of its original size so the cells stay proportional

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687f5d06140c8327a352bbbc05c8e593