### PR TITLE
Fix tavern hiring

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -347,7 +347,7 @@
                 runSceneEngineUnitTests(sceneEngine);
                 runLogicManagerUnitTests(logicManager);
                 runCompatibilityManagerUnitTests(compatibilityManager);
-                runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager, eventManager);
+                runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager, eventManager, heroEngine);
                 runPanelEngineUnitTests();
                 runBattleLogManagerUnitTests(eventManager, measureManager);
                 runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);
@@ -686,7 +686,7 @@
             runSceneEngineUnitTests(sceneEngine);
             runLogicManagerUnitTests(logicManager);
             runCompatibilityManagerUnitTests(compatibilityManager);
-            runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager, eventManager);
+            runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager, eventManager, heroEngine);
             runPanelEngineUnitTests();
             runBattleLogManagerUnitTests(eventManager, measureManager);
             runTurnEngineUnitTests(eventManager, battleSimulationManager, turnOrderManager, classAIManager, delayEngine, timingEngine, animationManager, battleCalculationManager);

--- a/js/GameEngine.js
+++ b/js/GameEngine.js
@@ -189,7 +189,7 @@ export class GameEngine {
         );
 
         // 6. UI, Input, Log & Other Managers
-        this.mercenaryPanelManager = new MercenaryPanelManager(this.measureManager, this.battleSimulationManager, this.logicManager, this.eventManager);
+        this.mercenaryPanelManager = new MercenaryPanelManager(this.measureManager, this.battleSimulationManager, this.logicManager, this.eventManager, this.heroEngine);
         this.buttonEngine = new ButtonEngine();
         const combatLogPanelElement = document.getElementById('battle-log-panel');
         if (!combatLogPanelElement) {
@@ -299,7 +299,16 @@ export class GameEngine {
         this.territoryUIManager = new TerritoryUIManager(this.eventManager, this.domEngine);
         this.territoryGridManager = new TerritoryGridManager(this.domEngine);
         this.heroDetailedUIManager = new HeroDetailedUIManager(this.domEngine, this.statManager);
-        this.tavernManager = new TavernManager(this.domEngine, this.sceneEngine, this.uiEngine, this.heroManager, this.heroDetailedUIManager);
+        this.tavernManager = new TavernManager(
+            this.domEngine,
+            this.sceneEngine,
+            this.uiEngine,
+            this.heroManager,
+            this.heroDetailedUIManager,
+            this.battleFormationManager,
+            this.battleSimulationManager,
+            this.mercenaryPanelManager
+        );
 
         // --- LAYER REGISTRATION ---
         this.layerEngine.registerLayer('combatScene', (ctx) => {

--- a/js/managers/MercenaryPanelManager.js
+++ b/js/managers/MercenaryPanelManager.js
@@ -1,10 +1,11 @@
 // js/managers/MercenaryPanelManager.js
 
 export class MercenaryPanelManager {
-    constructor(measureManager, battleSimulationManager, logicManager, eventManager) {
+    constructor(measureManager, battleSimulationManager, logicManager, eventManager, heroEngine) {
         console.log("\uD83D\uDC65 MercenaryPanelManager initialized. Ready to display mercenary details. \uD83D\uDC65");
         this.measureManager = measureManager;
         this.battleSimulationManager = battleSimulationManager;
+        this.heroEngine = heroEngine;
         this.logicManager = logicManager;
         this.eventManager = eventManager;
 
@@ -19,7 +20,7 @@ export class MercenaryPanelManager {
             return;
         }
         heroPanel.innerHTML = '';
-        const units = this.battleSimulationManager ? this.battleSimulationManager.unitsOnGrid : [];
+        const units = this.heroEngine ? this.heroEngine.getAllHeroes() : (this.battleSimulationManager ? this.battleSimulationManager.unitsOnGrid : []);
 
         for (let i = 0; i < this.numSlots; i++) {
             const slot = document.createElement('div');

--- a/js/managers/TavernManager.js
+++ b/js/managers/TavernManager.js
@@ -1,13 +1,16 @@
 import { GAME_DEBUG_MODE, UI_STATES } from '../constants.js';
 
 export class TavernManager {
-    constructor(domEngine, sceneEngine, uiEngine, heroManager, heroDetailedUIManager) {
+    constructor(domEngine, sceneEngine, uiEngine, heroManager, heroDetailedUIManager, battleFormationManager, battleSimulationManager, mercenaryPanelManager) {
         if (GAME_DEBUG_MODE) console.log('🍻 TavernManager initialized.');
         this.domEngine = domEngine;
         this.sceneEngine = sceneEngine;
         this.uiEngine = uiEngine;
         this.heroManager = heroManager;
         this.heroDetailedUIManager = heroDetailedUIManager;
+        this.battleFormationManager = battleFormationManager;
+        this.battleSimulationManager = battleSimulationManager;
+        this.mercenaryPanelManager = mercenaryPanelManager;
 
         // ✨ 고용 가능한 직업 및 관련 이미지 정보
         this.availableClasses = ['warrior', 'gunner', 'mage'];
@@ -113,8 +116,15 @@ export class TavernManager {
         if (GAME_DEBUG_MODE) console.log(`Attempting to hire a ${currentClass}.`);
         let classId = 'class_warrior';
         if (currentClass === 'gunner') classId = 'class_gunner';
+
         const hero = await this.heroManager.heroEngine.generateHero({ classId });
+
+        if (this.battleFormationManager && this.battleSimulationManager) {
+            this.battleFormationManager.placeAllies([hero]);
+        }
+
         this.closeHireUI();
         this.heroDetailedUIManager?.show(hero);
+        this.mercenaryPanelManager?.updatePanel();
     }
 }

--- a/tests/unit/mercenaryPanelManagerUnitTests.js
+++ b/tests/unit/mercenaryPanelManagerUnitTests.js
@@ -2,7 +2,7 @@
 
 import { MercenaryPanelManager } from '../../js/managers/MercenaryPanelManager.js';
 
-export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager, eventManager) {
+export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulationManager, logicManager, eventManager, heroEngine) {
     console.log("--- MercenaryPanelManager Unit Test Start ---");
 
     let testCount = 0;
@@ -17,7 +17,7 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
     // 테스트 1: 초기화 및 캔버스 속성 확인
     testCount++;
     try {
-        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager);
+        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager, heroEngine);
         if (panelManager.gridRows === 2 && panelManager.gridCols === 6) {
             console.log("MercenaryPanelManager: Initialized correctly. [PASS]");
             passCount++;
@@ -31,7 +31,7 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
     // 테스트 2: recalculatePanelDimensions 호출 후 슬롯 크기 확인
     testCount++;
     try {
-        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager);
+        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager, heroEngine);
         panelManager.recalculatePanelDimensions(); // 수동 호출
         const expectedSlotWidth = 600 / 6; // 600px / 6 cols
         const expectedSlotHeight = 200 / 2; // 200px / 2 rows
@@ -49,7 +49,7 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
     // 테스트 3: draw 메서드가 호출되는지 시각적 확인 (콘솔 로그를 통한 간접 확인)
     testCount++;
     try {
-        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager);
+        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager, heroEngine);
         const originalFillRect = mockCtx.fillRect;
         let fillRectCalled = false;
         mockCtx.fillRect = function(...args) {
@@ -83,7 +83,7 @@ export function runMercenaryPanelManagerUnitTests(measureManager, battleSimulati
         const originalUnitsOnGrid = battleSimulationManager.unitsOnGrid;
         battleSimulationManager.unitsOnGrid = [mockUnit];
 
-        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager);
+        const panelManager = new MercenaryPanelManager(measureManager, battleSimulationManager, logicManager, eventManager, heroEngine);
         const originalFillText = mockCtx.fillText;
         let fillTextCalledForUnit = false;
         mockCtx.fillText = function(text, ...args) {


### PR DESCRIPTION
## Summary
- connect tavern recruitment to party roster and hero panel
- pass hero engine to MercenaryPanelManager
- update debug page and tests

## Testing
- `npm test`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687f5e29445c8327a94873df146c66ab