### PR TITLE
Fix tavern grid overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -178,8 +178,8 @@ canvas {
 
 #tavern-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(2, 1fr);
+    grid-template-columns: repeat(4, 1fr); /* 가로로 한 줄 배치 */
+    grid-template-rows: 1fr;
     width: 80%;
     height: 60%;
     transform: scale(0.33);


### PR DESCRIPTION
## Summary
- fix overlapping grid cells in tavern screen

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687f607d2008832799e07d5339aec6d4